### PR TITLE
Fix `mint` and `desosit` methods to erc4626 spec

### DIFF
--- a/src/interfaces/IERC5095.sol
+++ b/src/interfaces/IERC5095.sol
@@ -35,9 +35,9 @@ interface IERC5095 is IERC2612 {
         address
     ) external returns (uint256);
 
-    function deposit(address, uint256) external returns (uint256);
+    function deposit(uint256, address) external returns (uint256);
 
-    function mint(address, uint256) external returns (uint256);
+    function mint(uint256, address) external returns (uint256);
 
     function authMint(address, uint256) external returns (bool);
 

--- a/src/tokens/ERC5095.sol
+++ b/src/tokens/ERC5095.sol
@@ -10,7 +10,7 @@ import 'src/errors/Exception.sol';
 
 import 'src/lib/Cast.sol';
 import 'src/lib/Safe.sol';
-
+ 
 contract ERC5095 is ERC20Permit, IERC5095 {
     /// @dev unix timestamp when the ERC5095 token can be redeemed
     uint256 public immutable override maturity;
@@ -181,39 +181,39 @@ contract ERC5095 is ERC20Permit, IERC5095 {
     }
 
     /// @notice Before maturity spends `a` of underlying, and sends PTs to `r`. Post or at maturity, reverts.
-    /// @param r The receiver of the principal tokens
     /// @param a The amount of underlying tokens deposited
+    /// @param r The receiver of the principal tokens
     /// @param m Minimum number of shares that the user will receive
     /// @return uint256 The amount of principal tokens purchased
-    function deposit(address r, uint256 a, uint256 m) external returns (uint256) {
+    function deposit(uint256 a, address r, uint256 m) external returns (uint256) {
         // Execute the deposit
         return _deposit(r, a, m);
     }
 
     /// @notice Before maturity spends `assets` of underlying, and sends `shares` of PTs to `receiver`. Post or at maturity, reverts.
-    /// @param r The receiver of the principal tokens
     /// @param a The amount of underlying tokens deposited
+    /// @param r The receiver of the principal tokens
     /// @return uint256 The amount of principal tokens burnt by the withdrawal
-    function deposit(address r, uint256 a) external override returns (uint256) {
+    function deposit(uint256 a, address r) external override returns (uint256) {
         // Execute the deposit
         return _deposit(r, a, 0);
     }
 
     /// @notice Before maturity mints `s` of PTs to `r` by spending underlying. Post or at maturity, reverts.
-    /// @param r The receiver of the underlying tokens being withdrawn
     /// @param s The amount of shares being minted
+    /// @param r The receiver of the underlying tokens being withdrawn
     /// @param m Maximum amount of underlying that the user will spend
     /// @return uint256 The amount of principal tokens purchased
-    function mint(address r, uint256 s, uint256 m) external returns (uint256) {
+    function mint(uint256 s, address r, uint256 m) external returns (uint256) {
         // Execute the mint
         return _mint(r, s, m);
     }
 
     /// @notice Before maturity mints `shares` of PTs to `receiver` by spending underlying. Post or at maturity, reverts.
-    /// @param r The receiver of the underlying tokens being withdrawn
     /// @param s The amount of shares being minted
+    /// @param r The receiver of the underlying tokens being withdrawn
     /// @return uint256 The amount of principal tokens purchased
-    function mint(address r, uint256 s) external override returns (uint256) {
+    function mint(uint256 s, address r) external override returns (uint256) {
         // Execute the mint
         return _mint(r, s, type(uint128).max);
     }

--- a/test/fork/ERC5095.t.sol
+++ b/test/fork/ERC5095.t.sol
@@ -173,7 +173,7 @@ contract ERC5095Test is Test {
         uint256 amount = 100000;
         deal(Contracts.USDC, address(this), amount);
         deal(address(token), address(token), amount * 2);
-        token.deposit(address(this), amount);
+        token.deposit(amount, address(this));
         assertEq(IERC20(Contracts.USDC).balanceOf(address(this)), 0);
         assertGt(IERC20(address(token)).balanceOf(address(this)), 0);
     }
@@ -185,17 +185,17 @@ contract ERC5095Test is Test {
         uint256 amount = 100000;
         deal(Contracts.USDC, address(this), amount);
         deal(address(token), address(token), amount * 2);
-        token.mint(address(this), amount);
+        token.mint(amount, address(this));
         assertGt(IERC20(address(token)).balanceOf(address(this)), 0);
     }
 
     function testFailTooLate() public {
         vm.warp(maturity + 1);
         vm.expectRevert(Exception.selector);
-        token.deposit(address(this), 100000);
+        token.deposit(100000, address(this));
 
         vm.expectRevert(Exception.selector);
-        token.mint(address(this), 100000);
+        token.mint(100000, address(this));
     }
 
     function testWithdrawPreMaturity() public {
@@ -293,10 +293,10 @@ contract ERC5095Test is Test {
         deal(address(token), address(token), amount * 2);
 
         vm.expectRevert(Exception.selector);
-        token.mint(address(this), amount, 0);
+        token.mint(amount, address(this), 0);
 
         vm.expectRevert(Exception.selector);
-        token.deposit(address(this), amount, 0);
+        token.deposit(amount, address(this), 0);
 
         vm.expectRevert(Exception.selector);
         token.withdraw(amount, address(this), address(this), type(uint256).max);


### PR DESCRIPTION
This PR addresses an issue brought up by the following [escalation](https://github.com/sherlock-audit/2023-01-illuminate-judging/issues/15#issuecomment-1407375039) in the follow-up audit.