### PR TITLE
Fix constraints on swap

### DIFF
--- a/script/FederationDeployer.s.sol
+++ b/script/FederationDeployer.s.sol
@@ -3,34 +3,30 @@ pragma solidity 0.8.16;
 
 import 'forge-std/Script.sol';
 
-import {Lender} from 'flattened/Lender.flattened.sol';
-import {MarketPlace} from 'flattened/MarketPlace.flattened.sol';
-import {Redeemer} from 'flattened/Redeemer.flattened.sol';
-import {Converter} from 'flattened/Converter.flattened.sol';
-import {Creator} from 'flattened/Creator.flattened.sol';
+import {Lender} from 'src/Lender.sol';
+import {MarketPlace} from 'src/MarketPlace.sol';
+import {Redeemer} from 'src/Redeemer.sol';
+import {Converter} from 'src/Converter.sol';
+import {Creator} from 'src/Creator.sol';
 
 contract IlluminateFederationDeployer is Script {
-    address admin;
+    address admin = 0x173033758E8623fEE7C612e2f251CEa808127654;
     // third party contracts for lender and redeemer
-    address swivel;
-    address pendle;
-    address apwine;
-    address tempus;
+    address swivel = 0x373a06bD3067f8DA90239a47f316F09312b7800F;
+    address pendle = 0x41FAD93F225b5C1C95f2445A5d7fcB85bA46713f;
+    address apwine = 0xf5ba2E5DdED276fc0f7a7637A61157a4be79C626;
+    address tempus = 0xdB5fD0678eED82246b599da6BC36B56157E4beD8;
 
     function run() external {
         // setup deployer contract
-        uint256 deployerPrivateKey = vm.envUint('');
+        uint256 deployerPrivateKey = vm.envUint('MAINNET_PRIVATE_KEY');
 
         vm.startBroadcast(deployerPrivateKey);
 
         // Deploy contracts
         Creator creator = new Creator();
         Lender lender = new Lender(swivel, pendle, apwine);
-        Redeemer redeemer = new Redeemer(
-            address(lender),
-            swivel,
-            tempus
-        );
+        Redeemer redeemer = new Redeemer(address(lender), swivel, tempus);
         MarketPlace marketplace = new MarketPlace(
             address(redeemer),
             address(lender),

--- a/src/Marketplace.sol
+++ b/src/Marketplace.sol
@@ -114,11 +114,7 @@ contract MarketPlace {
     /// @param r address of the deployed redeemer contract
     /// @param l address of the deployed lender contract
     /// @param c address of the deployed creator contract
-    constructor(
-        address r,
-        address l,
-        address c
-    ) {
+    constructor(address r, address l, address c) {
         admin = msg.sender;
         redeemer = r;
         lender = l;
@@ -294,7 +290,7 @@ contract MarketPlace {
         // Set the pool for the principal token
         pt.setPool(a);
 
-        // Approve the marketplace to spend the principal and underlying tokens 
+        // Approve the marketplace to spend the principal and underlying tokens
         pt.approveMarketPlace();
 
         emit SetPool(u, m, a);
@@ -333,7 +329,7 @@ contract MarketPlace {
         );
 
         // Execute the swap
-        uint128 received = pool.sellFYToken(msg.sender, Cast.u128(expected));
+        uint128 received = pool.sellFYToken(msg.sender, s);
         emit Swap(u, m, address(pool.fyToken()), u, received, a, msg.sender);
 
         return received;
@@ -372,7 +368,7 @@ contract MarketPlace {
         );
 
         // Execute the swap to purchase `a` base tokens
-        uint128 spent = pool.buyFYToken(msg.sender, a, expected);
+        uint128 spent = pool.buyFYToken(msg.sender, a, s);
 
         emit Swap(u, m, u, address(pool.fyToken()), a, spent, msg.sender);
         return spent;
@@ -405,7 +401,7 @@ contract MarketPlace {
         Safe.transferFrom(IERC20(pool.base()), msg.sender, address(pool), a);
 
         // Execute the swap
-        uint128 received = pool.sellBase(msg.sender, expected);
+        uint128 received = pool.sellBase(msg.sender, s);
 
         emit Swap(u, m, u, address(pool.fyToken()), received, a, msg.sender);
         return received;
@@ -444,7 +440,7 @@ contract MarketPlace {
         );
 
         // Execute the swap to purchase `a` underlying tokens
-        uint128 spent = pool.buyBase(msg.sender, a, Cast.u128(expected));
+        uint128 spent = pool.buyBase(msg.sender, a, s);
 
         emit Swap(u, m, address(pool.fyToken()), u, a, spent, msg.sender);
         return spent;
@@ -469,14 +465,7 @@ contract MarketPlace {
         uint256 p,
         uint256 minRatio,
         uint256 maxRatio
-    )
-        external
-        returns (
-            uint256,
-            uint256,
-            uint256
-        )
-    {
+    ) external returns (uint256, uint256, uint256) {
         // Get the pool for the market
         IPool pool = IPool(pools[u][m]);
 
@@ -518,14 +507,7 @@ contract MarketPlace {
         uint256 p,
         uint256 minRatio,
         uint256 maxRatio
-    )
-        external
-        returns (
-            uint256,
-            uint256,
-            uint256
-        )
-    {
+    ) external returns (uint256, uint256, uint256) {
         // Get the pool for the market
         IPool pool = IPool(pools[u][m]);
 
@@ -560,14 +542,7 @@ contract MarketPlace {
         uint256 a,
         uint256 minRatio,
         uint256 maxRatio
-    )
-        external
-        returns (
-            uint256,
-            uint256,
-            uint256
-        )
-    {
+    ) external returns (uint256, uint256, uint256) {
         // Get the pool for the market
         IPool pool = IPool(pools[u][m]);
 
@@ -626,11 +601,9 @@ contract MarketPlace {
 
     /// @notice Allows batched call to self (this contract).
     /// @param c An array of inputs for each call.
-    function batch(bytes[] calldata c)
-        external
-        payable
-        returns (bytes[] memory results)
-    {
+    function batch(
+        bytes[] calldata c
+    ) external payable returns (bytes[] memory results) {
         results = new bytes[](c.length);
         for (uint256 i; i < c.length; i++) {
             (bool success, bytes memory result) = address(this).delegatecall(


### PR DESCRIPTION
Previously, the swap slippage limits were based on the preview, rather than user inputs. This caused potential overfitting and could break certain pools. 