### PR TITLE
Implement Swivel's adapter

### DIFF
--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -36,7 +36,7 @@ contract Lender {
 
     /// @notice protocol specific addresses that adapters reference when executing lends
     /// @dev these addresses are references by an implied enum; adapters hardcode the index for their protocol
-    address[] public protocolAddressess;
+    address[] public protocolRouters;
 
     /// @notice a mapping that tracks the amount of unswapped premium by market. This underlying is later transferred to the Redeemer during Swivel's redeem call
     mapping(address => mapping(uint256 => uint256)) public premiums;
@@ -157,9 +157,9 @@ contract Lender {
     /// @param a the APWine contract
     constructor(address s, address p, address a) {
         admin = msg.sender;
-        protocolAddressess.push(s);
-        protocolAddressess.push(p);
-        protocolAddressess.push(a);
+        protocolRouters.push(s);
+        protocolRouters.push(p);
+        protocolRouters.push(a);
         feenominator = 1000;
     }
 
@@ -465,9 +465,14 @@ contract Lender {
     }
 
     /// @notice allows admin to add a protocol contract for reference by adapters
-    /// @param a address of a new protocol contract
-    function addContract(address a) external authorized(admin) {
-        protocolAddressess.push(a);
+    /// @param r address of a new protocol contract
+    function addRouter(address r) external authorized(admin) {
+        protocolRouters.push(r);
+    }
+
+    /// @notice allows admin to change the router contract for reference by adapters
+    function setRouter(address r, uint256 i) external authorized(admin) {
+        protocolRouters[i] = r;
     }
 
     /// @notice Tranfers FYTs to Redeemer (used specifically for APWine redemptions)

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -34,12 +34,9 @@ contract Lender {
     /// @notice flag that allows admin to stop all lending and minting across the entire protocol
     bool public halted;
 
-    /// @notice contract used to execute swaps on Swivel's exchange
-    address public immutable swivelAddr;
-    /// @notice a SushiSwap router used by Pendle to execute swaps
-    address public immutable pendleAddr;
-    /// @notice a pool router used by APWine to execute swaps
-    address public immutable apwineAddr;
+    /// @notice protocol specific addresses that adapters reference when executing lends
+    /// @dev these addresses are references by an implied enum; adapters hardcode the index for their protocol
+    address[] public protocolAddressess;
 
     /// @notice a mapping that tracks the amount of unswapped premium by market. This underlying is later transferred to the Redeemer during Swivel's redeem call
     mapping(address => mapping(uint256 => uint256)) public premiums;
@@ -160,9 +157,9 @@ contract Lender {
     /// @param a the APWine contract
     constructor(address s, address p, address a) {
         admin = msg.sender;
-        swivelAddr = s;
-        pendleAddr = p;
-        apwineAddr = a;
+        protocolAddressess.push(s);
+        protocolAddressess.push(p);
+        protocolAddressess.push(a);
         feenominator = 1000;
     }
 
@@ -213,38 +210,6 @@ contract Lender {
             }
         }
         return true;
-    }
-
-    /// @notice approves market contracts that require lender approval
-    /// @param u address of an underlying asset
-    /// @param a APWine's router contract
-    /// @param e Element's vault contract
-    /// @param n Notional's token contract
-    /// @param p Sense's periphery contract
-    function approve(
-        address u,
-        address a,
-        address e,
-        address n,
-        address p
-    ) external authorized(marketPlace) {
-        uint256 max = type(uint256).max;
-        IERC20 uToken = IERC20(u);
-        if (a != address(0)) {
-            Safe.approve(uToken, a, max);
-        }
-        if (e != address(0)) {
-            Safe.approve(uToken, e, max);
-        }
-        if (n != address(0)) {
-            Safe.approve(uToken, n, max);
-        }
-        if (p != address(0)) {
-            Safe.approve(uToken, p, max);
-        }
-        if (IERC20(u).allowance(address(this), swivelAddr) == 0) {
-            Safe.approve(uToken, swivelAddr, max);
-        }
     }
 
     /// @notice sets the admin address
@@ -548,11 +513,8 @@ contract Lender {
         // Fetch the principal token for this lend call
         address pt = IMarketPlace(marketPlace).markets(u, m, p);
 
-        // Get the starting balance for the Lender
-        uint256 starting = IERC20(pt).balanceOf(address(this));
-
         // Conduct the lend operation to acquire principal tokens
-        (bool success, ) = adapter.delegatecall(
+        (bool success, bytes memory returndata) = adapter.delegatecall(
             abi.encodeWithSignature('lend(bytes calldata inputdata)', d) // TODO: create lend signature
         );
 
@@ -560,8 +522,11 @@ contract Lender {
             revert Exception(0, 0, 0, address(0), address(0)); // TODO: assign exception
         }
 
-        // Fetch how many principal tokens were obtained
-        uint256 obtained = IERC20(pt).balanceOf(address(this)) - starting;
+        // Get the amount of PTs (in protocol decimals) received
+        uint256 obtained = abi.decode(returndata, (uint256));
+
+        // Extract fee
+        fees[u] += a / feenominator;
 
         // Convert decimals from principal token to underlying
         uint256 returned = convertDecimals(u, pt, obtained);

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -464,6 +464,12 @@ contract Lender {
         return true;
     }
 
+    /// @notice allows admin to add a protocol contract for reference by adapters
+    /// @param a address of a new protocol contract
+    function addContract(address a) external authorized(admin) {
+        protocolAddressess.push(a);
+    }
+
     /// @notice Tranfers FYTs to Redeemer (used specifically for APWine redemptions)
     /// @param f FYT contract address
     /// @param a amount of tokens to send to the redeemer

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -127,7 +127,7 @@ contract SwivelAdapter is IAdapter {
 
         // execute the orders
         uint256 premium = IERC20(underlying).balanceOf(address(this));
-        ISwivel(address(0)).initiate(orders, amounts, components);
+        ISwivel(protocolAddressess[0]).initiate(orders, amounts, components);
         premium = IERC20(underlying).balanceOf(address(this)) - premium;
         received = IERC20(pt).balanceOf(address(this)) - received;
 

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -144,7 +144,7 @@ contract SwivelAdapter is IAdapter {
 
         // Swap the premium for iPTs or return premium to the sender
         if (swapFlag) {
-            received += swap(pool, premium, slippage);
+            received += swap(pool, underlying, premium, slippage);
         } else {
             premiums[underlying][maturity] += premium;
             received += premium;
@@ -155,10 +155,19 @@ contract SwivelAdapter is IAdapter {
 
     /// @notice facilitates a swap for Illuminate's principal tokens
     /// @param p Yield Space pool for the market
+    /// @param u underlying asset being sold for PTs
     /// @param a amount of underlying to be swapped
     /// @param m minimum number of tokens to receive
     /// @return received amount of PTs received in swap
-    function swap(address p, uint256 a, uint256 m) internal returns (uint256) {
+    function swap(
+        address p,
+        address u,
+        uint256 a,
+        uint256 m
+    ) internal returns (uint256) {
+        // transfer funds to the pool
+        Safe.transfer(IERC20(u), p, a);
+
         uint256 received = IYield(p).sellBase(address(this), uint128(a));
         if (received < m) {
             revert Exception(0, 0, 0, address(0), address(0)); // TODO: add exception code

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.20;
+
+import {IAdapter} from 'src/interfaces/IAdapter.sol';
+import {ISwivel} from 'src/interfaces/ISwivel.sol';
+import {IERC20} from 'src/interfaces/IERC20.sol';
+import {IYield} from 'src/interfaces/IYield.sol';
+import {IMarketPlace} from 'src/interfaces/IMarketPlace.sol';
+
+import {Swivel} from 'src/lib/Swivel.sol';
+import {Exception} from 'src/errors/Exception.sol';
+
+// NOTE: The storage of the adapter _must_ exactly match the storage layout of the Lender
+contract SwivelAdapter is IAdapter {
+    /// @notice minimum wait before the admin may withdraw funds or change the fee rate
+    uint256 public constant HOLD = 3 days;
+
+    /// @notice address that is allowed to set and withdraw fees, disable principals, etc. It is commonly used in the authorized modifier.
+    address public admin;
+    /// @notice address of the MarketPlace contract, used to access the markets mapping
+    address public marketPlace;
+    /// @notice mapping that determines if a principal has been paused by the admin
+    mapping(uint8 => bool) public paused;
+    /// @notice flag that allows admin to stop all lending and minting across the entire protocol
+    bool public halted;
+
+    /// @notice protocol specific addresses that adapters reference when executing lends
+    /// @dev these addresses are references by an implied enum; adapters hardcode the index for their protocol
+    address[] public protocolAddressess;
+
+    /// @notice a mapping that tracks the amount of unswapped premium by market. This underlying is later transferred to the Redeemer during Swivel's redeem call
+    mapping(address => mapping(uint256 => uint256)) public premiums;
+
+    /// @notice this value determines the amount of fees paid on loans
+    uint256 public feenominator;
+    /// @notice represents a point in time where the feenominator may change
+    uint256 public feeChange;
+    /// @notice represents a minimum that the feenominator must exceed
+    uint256 public constant MIN_FEENOMINATOR = 500;
+
+    /// @notice maps underlying tokens to the amount of fees accumulated for that token
+    mapping(address => uint256) public fees;
+    /// @notice maps a token address to a point in time, a hold, after which a withdrawal can be made
+    mapping(address => uint256) public withdrawals;
+
+    // Reantrancy protection
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+    uint256 private _status = _NOT_ENTERED;
+
+    // Rate limiting protection
+    /// @notice maximum amount of value that can flow through a protocol in a day (in USD)
+    uint256 public maximumValue = 250_000e27;
+    /// @notice maps protocols to how much value, in USD, has flowed through each protocol
+    mapping(uint8 => uint256) public protocolFlow;
+    /// @notice timestamp from which values flowing through protocol has begun
+    mapping(uint8 => uint256) public periodStart;
+    /// @notice estimated price of ether, set by the admin
+    uint256 public etherPrice = 2_500;
+
+    function approve(address[] calldata a) external {}
+
+    function lend(bytes calldata d) external returns (uint256) {
+        // Parse the calldata into the arguments
+        (
+            uint256[] memory amounts,
+            Swivel.Order[] memory orders,
+            Swivel.Components[] memory components,
+            address pool,
+            uint256 slippage,
+            bool swapFlag
+        ) = abi.decode(
+                d,
+                (
+                    uint256[],
+                    Swivel.Order[],
+                    Swivel.Components[],
+                    address,
+                    uint256,
+                    bool
+                )
+            );
+
+        // Cache a couple oft-referenced variables
+        address underlying = orders[0].underlying;
+        uint256 maturity = orders[0].maturity;
+        address pt = IMarketPlace(marketPlace).markets(underlying, maturity, 1);
+
+        // verify orders are for the same underlying
+        {
+            for (uint256 i = 0; i < orders.length; ) {
+                if (
+                    underlying != orders[i].underlying ||
+                    maturity != orders[i].maturity
+                ) {
+                    revert Exception(0, 0, 0, address(0), address(0)); // TODO: assign exception code
+                }
+
+                unchecked {
+                    i++;
+                }
+            }
+        }
+
+        // get the amount of the orders
+        {
+            uint256 total;
+            for (uint256 i = 0; i < amounts.length; ) {
+                total += amounts[i];
+
+                // extract fee
+                if (i == amounts.length - 1) {
+                    uint256 fee = total / 1000; // todo: fetch feenominator
+                    amounts[i] = amounts[i] - fee;
+                    total = total - fee;
+                }
+
+                unchecked {
+                    i++;
+                }
+            }
+        }
+
+        // store amount of iPTs to be minted to user
+        uint256 received = IERC20(pt).balanceOf(address(this));
+
+        // execute the orders
+        uint256 premium = IERC20(underlying).balanceOf(address(this));
+        ISwivel(address(0)).initiate(orders, amounts, components);
+        premium = IERC20(underlying).balanceOf(address(this)) - premium;
+        received = IERC20(pt).balanceOf(address(this)) - received;
+
+        // Swap the premium for iPTs or return premium to the sender
+        if (swapFlag) {
+            received += swap(pool, premium, slippage);
+        } else {
+            premiums[underlying][maturity] += premium;
+            received += premium;
+        }
+
+        return received;
+    }
+
+    /// @notice facilitates a swap for Illuminate's principal tokens
+    /// @param p Yield Space pool for the market
+    /// @param a amount of underlying to be swapped
+    /// @param m minimum number of tokens to receive
+    /// @return received amount of PTs received in swap
+    function swap(address p, uint256 a, uint256 m) internal returns (uint256) {
+        uint256 received = IYield(p).sellBase(address(this), uint128(a));
+        if (received < m) {
+            revert Exception(0, 0, 0, address(0), address(0)); // TODO: add exception code
+        }
+
+        return received;
+    }
+}

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -5,5 +5,5 @@ pragma solidity 0.8.20;
 interface IAdapter {
     function approve(address[] calldata) external;
 
-    function lend(bytes calldata) external returns (uint256);
+    function lend(bytes calldata) external returns (uint256, uint256);
 }

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.20;
+
+interface IAdapter {
+    function approve(address[] calldata) external;
+
+    function lend(bytes calldata) external returns (uint256);
+}


### PR DESCRIPTION
This PR includes several "first-time" changes that came from more clarity with respect to using `delegatecall`.

A few comments for clarity:
1. The state layout of an adapter must match that of it's calling (`msg.sender`) contract. As a result, I've copied the `Lender` state over to the adapter as it contains the relevant state to the adapter when conducting `lend` calls. The MarketPlace does not require this as it is only interested in calling `approve`.
2. I removed the individual state variables (e.g. `swivelAddr`, `pendleAddr` and `apwineAddr`) and replaced it with a dynamically-sized array called `protocolAddresses`. This was necessary to facilitate the addition of new protocols and their respective special contracts. It will also allow for new adapters to reference protocol-specific contracts.
3. I changed the adapter's `lend` call signature to include a return of the amount of iPTs to mint to the caller. Previously, we would use the change in PT balance on the Lender to determine the mintable amount. This does not cover all case; Swivel has a premium component that must be accounted for. As a result, the adapter is now responsible for returning the amount PTs to mint to the user (in decimals of the protocol PTs). The Lender still converts the amount to the market's PT amount.