### PR TITLE
Implement Yield's adapter (alongside more fixes)

### DIFF
--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -7,69 +7,27 @@ import {ISwivel} from 'src/interfaces/ISwivel.sol';
 import {IERC20} from 'src/interfaces/IERC20.sol';
 import {IYield} from 'src/interfaces/IYield.sol';
 import {IMarketPlace} from 'src/interfaces/IMarketPlace.sol';
+import {Lender} from 'src/Lender.sol';
 
 import {Swivel} from 'src/lib/Swivel.sol';
 import {Exception} from 'src/errors/Exception.sol';
 import {Safe} from 'src/lib/Safe.sol';
 
-// NOTE: The storage of the adapter _must_ exactly match the storage layout of the Lender
-contract SwivelAdapter is IAdapter {
-    /// @notice minimum wait before the admin may withdraw funds or change the fee rate
-    uint256 public constant HOLD = 3 days;
+contract SwivelAdapter is IAdapter, Lender {
+    constructor() Lender(address(0), address(0), address(0)) {}
 
-    /// @notice address that is allowed to set and withdraw fees, disable principals, etc. It is commonly used in the authorized modifier.
-    address public admin;
-    /// @notice address of the MarketPlace contract, used to access the markets mapping
-    address public marketPlace;
-    /// @notice mapping that determines if a principal has been paused by the admin
-    mapping(uint8 => bool) public paused;
-    /// @notice flag that allows admin to stop all lending and minting across the entire protocol
-    bool public halted;
+    address public lender = address(0);
 
-    /// @notice protocol specific addresses that adapters reference when executing lends
-    /// @dev these addresses are references by an implied enum; adapters hardcode the index for their protocol
-    address[] public protocolRouters;
-
-    /// @notice a mapping that tracks the amount of unswapped premium by market. This underlying is later transferred to the Redeemer during Swivel's redeem call
-    mapping(address => mapping(uint256 => uint256)) public premiums;
-
-    /// @notice this value determines the amount of fees paid on loans
-    uint256 public feenominator;
-    /// @notice represents a point in time where the feenominator may change
-    uint256 public feeChange;
-    /// @notice represents a minimum that the feenominator must exceed
-    uint256 public constant MIN_FEENOMINATOR = 500;
-
-    /// @notice maps underlying tokens to the amount of fees accumulated for that token
-    mapping(address => uint256) public fees;
-    /// @notice maps a token address to a point in time, a hold, after which a withdrawal can be made
-    mapping(address => uint256) public withdrawals;
-
-    // Reantrancy protection
-    uint256 private constant _NOT_ENTERED = 1;
-    uint256 private constant _ENTERED = 2;
-    uint256 private _status = _NOT_ENTERED;
-
-    // Rate limiting protection
-    /// @notice maximum amount of value that can flow through a protocol in a day (in USD)
-    uint256 public maximumValue = 250_000e27;
-    /// @notice maps protocols to how much value, in USD, has flowed through each protocol
-    mapping(uint8 => uint256) public protocolFlow;
-    /// @notice timestamp from which values flowing through protocol has begun
-    mapping(uint8 => uint256) public periodStart;
-    /// @notice estimated price of ether, set by the admin
-    uint256 public etherPrice = 2_500;
-
-    function approve(address[] calldata a) external {
-        for (uint256 i = 0; i < a.length; ) {
-            IERC20(a[i]).approve(protocolRouters[0], type(uint256).max);
-            unchecked {
-                i++;
-            }
+    modifier authorizedLender() {
+        if (address(this) != lender) {
+            revert Exception(0, 0, 0, address(0), address(0));
         }
+        _;
     }
 
-    function lend(bytes calldata d) external returns (uint256, uint256) {
+    function lend(
+        bytes calldata d
+    ) external authorizedLender returns (uint256, uint256) {
         // Parse the calldata into the arguments
         (
             uint256[] memory amounts,

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -20,7 +20,7 @@ contract SwivelAdapter is IAdapter, Lender {
 
     modifier authorizedLender() {
         if (address(this) != lender) {
-            revert Exception(0, 0, 0, address(0), address(0));
+            revert Exception(0, 0, 0, address(0), address(0)); // TODO: add exception value
         }
         _;
     }

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -61,13 +61,8 @@ contract SwivelAdapter is IAdapter {
     uint256 public etherPrice = 2_500;
 
     function approve(address[] calldata a) external {
-        address[] memory underlyings = abi.decode('', (address[]));
-
-        for (uint256 i = 0; i < underlyings.length; ) {
-            IERC20(underlyings[i]).approve(
-                protocolRouters[0],
-                type(uint256).max
-            );
+        for (uint256 i = 0; i < a.length; ) {
+            IERC20(a[i]).approve(protocolRouters[0], type(uint256).max);
             unchecked {
                 i++;
             }

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -18,16 +18,9 @@ contract SwivelAdapter is IAdapter, Lender {
 
     address public lender = address(0);
 
-    modifier authorizedLender() {
-        if (address(this) != lender) {
-            revert Exception(0, 0, 0, address(0), address(0)); // TODO: add exception value
-        }
-        _;
-    }
-
     function lend(
         bytes calldata d
-    ) external authorizedLender returns (uint256, uint256) {
+    ) external authorized(lender) returns (uint256, uint256) {
         // Parse the calldata into the arguments
         (
             uint256[] memory amounts,

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.20;
+
+import {Lender} from 'src/Lender.sol';
+
+import {IAdapter} from 'src/interfaces/IAdapter.sol';
+import {IERC20} from 'src/interfaces/IERC20.sol';
+import {IYield} from 'src/interfaces/IYield.sol';
+import {IMarketPlace} from 'src/interfaces/IMarketPlace.sol';
+
+import {Exception} from 'src/errors/Exception.sol';
+import {Safe} from 'src/lib/Safe.sol';
+
+contract YieldAdapter is IAdapter, Lender {
+    constructor() Lender(address(0), address(0), address(0)) {}
+
+    address public lender = address(0);
+
+    modifier authorizedLender() {
+        if (address(this) != lender) {
+            revert Exception(0, 0, 0, address(0), address(0));
+        }
+        _;
+    }
+
+    function lend(
+        bytes calldata d
+    ) external authorizedLender returns (uint256, uint256) {
+        // Parse the calldata
+        (
+            address underlying,
+            uint256 maturity,
+            address pool,
+            uint256 amount,
+            uint256 minimum
+        ) = abi.decode(d, (address, uint256, address, uint256, uint256));
+
+        address pt = IMarketPlace(marketPlace).markets(underlying, maturity, 0);
+
+        // Receive underlying funds, extract fees
+        Safe.transferFrom(
+            IERC20(underlying),
+            msg.sender,
+            address(this),
+            amount
+        );
+
+        uint256 fee = amount / feenominator;
+        fees[underlying] += fee;
+        amount = amount - fee;
+
+        // Execute the order
+        uint256 starting = IERC20(pt).balanceOf(address(this));
+        Safe.transfer(IERC20(underlying), pool, amount);
+        IYield(pool).sellBase(address(this), uint128(minimum));
+        uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
+
+        return (received, amount + fee);
+    }
+}

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -40,11 +40,10 @@ contract YieldAdapter is IAdapter, Lender {
 
         uint256 fee = amount / feenominator;
         fees[underlying] += fee;
-        uint256 lent = amount - fee;
 
         // Execute the order
         uint256 starting = IERC20(pt).balanceOf(address(this));
-        Safe.transfer(IERC20(underlying), pool, lent);
+        Safe.transfer(IERC20(underlying), pool, amount - fee);
         IYield(pool).sellBase(address(this), uint128(minimum));
         uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
 

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -48,14 +48,14 @@ contract YieldAdapter is IAdapter, Lender {
 
         uint256 fee = amount / feenominator;
         fees[underlying] += fee;
-        amount = amount - fee;
+        uint256 lent = amount - fee;
 
         // Execute the order
         uint256 starting = IERC20(pt).balanceOf(address(this));
-        Safe.transfer(IERC20(underlying), pool, amount);
+        Safe.transfer(IERC20(underlying), pool, lent);
         IYield(pool).sellBase(address(this), uint128(minimum));
         uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
 
-        return (received, amount + fee);
+        return (received, amount);
     }
 }

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -19,7 +19,7 @@ contract YieldAdapter is IAdapter, Lender {
 
     modifier authorizedLender() {
         if (address(this) != lender) {
-            revert Exception(0, 0, 0, address(0), address(0));
+            revert Exception(0, 0, 0, address(0), address(0)); // TODO: add exception value
         }
         _;
     }

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -9,7 +9,6 @@ import {IERC20} from 'src/interfaces/IERC20.sol';
 import {IYield} from 'src/interfaces/IYield.sol';
 import {IMarketPlace} from 'src/interfaces/IMarketPlace.sol';
 
-import {Exception} from 'src/errors/Exception.sol';
 import {Safe} from 'src/lib/Safe.sol';
 
 contract YieldAdapter is IAdapter, Lender {
@@ -17,16 +16,9 @@ contract YieldAdapter is IAdapter, Lender {
 
     address public lender = address(0);
 
-    modifier authorizedLender() {
-        if (address(this) != lender) {
-            revert Exception(0, 0, 0, address(0), address(0)); // TODO: add exception value
-        }
-        _;
-    }
-
     function lend(
         bytes calldata d
-    ) external authorizedLender returns (uint256, uint256) {
+    ) external authorized(lender) returns (uint256, uint256) {
         // Parse the calldata
         (
             address underlying,

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -3,7 +3,5 @@
 pragma solidity 0.8.20;
 
 interface IAdapter {
-    function approve(address[] calldata) external;
-
     function lend(bytes calldata) external returns (uint256, uint256);
 }


### PR DESCRIPTION
This PR implements the adapter for Yield.

In addition, it contains three key tweaks:

1. Remove redundant `approve` method for adapters. Because adapters adopt the state of the caller contract, we don't need to have specific `approve` methods by adapter. Instead, we can use the Lender's original `approve` methods to accomplish the same goal.
2. Add an `authorizedLender` modifier to the adapter. This ensures that _only_ the Lender may use `delegatecall` to execute the logic within the adapters. This is necessary to prevent a malicious party from manipulating the Lender's state prior to or after the `lend` call in a way that may harm the state of the Illuminate protocol.
3. In lieu of copying the state layout of the Lender contract into each adapter, this PR has the adapter extend the Lender contract instead. This allows us to still reference the Lender without having to copy/paste the Lender's state layout every time we change it.
