### PR TITLE
Market struct and Initial ETH Wrapper integration

### DIFF
--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -554,35 +554,38 @@ contract Lender {
         return returned;
     }
 
+    // @notice: Handles all lending to ETH markets and any swaps necessary
+    // @param adapter: The adapter contract to lend through
+    // @param d: The calldata for the lend (and potentially swap) operation
     function ETHLend(address adapter, bytes calldata d) internal returns (bool success, bytes memory returndata) {
         // Parse the calldata
-            (
-                address underlying,
-                uint256 maturity,
-                address pool,
-                uint256 amount,
-                uint256 minimum,
-                address lst,
-                uint256 swapMinimum
-            ) = abi.decode(d, (address, uint256, address, uint256, uint256, address, uint256));
-            // If the "lst" address is populated, a swap is required
-            if (lst != address(0)) {
-                amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
-                // Encode to the adapter interface
-                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
-                // Conduct the lend operation to acquire principal tokens
-                (success, returndata) = adapter.delegatecall(
-                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
-                return (success, returndata);
-            }
-            // If the `lst` address is blank, no swap is necessary
-            else { 
-                // Encode to the adapter interface
-                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
-                // Conduct the lend operation to acquire principal tokens
-                (success, returndata) = adapter.delegatecall(
-                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
-            }
+        (
+            address underlying,
+            uint256 maturity,
+            address pool,
+            uint256 amount,
+            uint256 minimum,
+            address lst,
+            uint256 swapMinimum
+        ) = abi.decode(d, (address, uint256, address, uint256, uint256, address, uint256));
+        // If the "lst" address is populated, a swap is required
+        if (lst != address(0)) {
+            amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
+            // Encode to the adapter interface
+            bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
+            // Conduct the lend operation to acquire principal tokens
+            (success, returndata) = adapter.delegatecall(
+                abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+            return (success, returndata);
+        }
+        // If the `lst` address is blank, no swap is necessary
+        else { 
+            // Encode to the adapter interface
+            bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
+            // Conduct the lend operation to acquire principal tokens
+            (success, returndata) = adapter.delegatecall(
+                abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+        }
     }
 
     /// @notice Allows batched call to self (this contract).

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -746,8 +746,8 @@ contract Lender {
         uint256 valueToMint = a;
 
         // In case of stETH, we will calculate an approximate USD value
-        // 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84 (stETH address)
-        if (u == 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84) {
+        // 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2 (WETH address)
+        if (u == 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) {
             valueToMint = etherPrice * valueToMint;
         }
 

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -535,13 +535,20 @@ contract Lender {
             address lst,
             uint256 swapMinimum
         ) = abi.decode(d, (address, uint256, address, uint256, uint256, address, uint256));
+            if (lst != address(0)) {
+                amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
 
-            amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
-
-            bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
-            // Conduct the lend operation to acquire principal tokens
-            (success, returndata) = adapter.delegatecall(
-                abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
+                // Conduct the lend operation to acquire principal tokens
+                (success, returndata) = adapter.delegatecall(
+                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+            }
+            else {
+                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
+                // Conduct the lend operation to acquire principal tokens
+                (success, returndata) = adapter.delegatecall(
+                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+            }
         }
         else {
             // Conduct the lend operation to acquire principal tokens

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -526,7 +526,7 @@ contract Lender {
         bool success;
         // If the underlying is WETH, the market is for ETH and `d` contains additional parameters
         if (u == 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) {
-            ETHLend(adapter, d);
+            (success, returndata) = ETHLend(adapter, d);
         }
         // If the underlying is not WETH, no extra swaps or parameters are necessary
         else {

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -526,33 +526,7 @@ contract Lender {
         bool success;
         // If the underlying is WETH, the market is for ETH and `d` contains additional parameters
         if (u == 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) {
-            // Parse the calldata
-        (
-            address underlying,
-            uint256 maturity,
-            address pool,
-            uint256 amount,
-            uint256 minimum,
-            address lst,
-            uint256 swapMinimum
-        ) = abi.decode(d, (address, uint256, address, uint256, uint256, address, uint256));
-            // If the "lst" address is populated, a swap is required
-            if (lst != address(0)) {
-                amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
-                // Encode to the adapter interface
-                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
-                // Conduct the lend operation to acquire principal tokens
-                (success, returndata) = adapter.delegatecall(
-                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
-            }
-            // If the `lst` address is blank, no swap is necessary
-            else { 
-                // Encode to the adapter interface
-                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
-                // Conduct the lend operation to acquire principal tokens
-                (success, returndata) = adapter.delegatecall(
-                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
-            }
+            ETHLend(adapter, d);
         }
         // If the underlying is not WETH, no extra swaps or parameters are necessary
         else {
@@ -578,6 +552,37 @@ contract Lender {
         IERC5095(principalToken(u, m)).authMint(msg.sender, returned);
         emit Lend(p, u, m, returned, spent, msg.sender);
         return returned;
+    }
+
+    function ETHLend(address adapter, bytes calldata d) internal returns (bool success, bytes memory returndata) {
+        // Parse the calldata
+            (
+                address underlying,
+                uint256 maturity,
+                address pool,
+                uint256 amount,
+                uint256 minimum,
+                address lst,
+                uint256 swapMinimum
+            ) = abi.decode(d, (address, uint256, address, uint256, uint256, address, uint256));
+            // If the "lst" address is populated, a swap is required
+            if (lst != address(0)) {
+                amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
+                // Encode to the adapter interface
+                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
+                // Conduct the lend operation to acquire principal tokens
+                (success, returndata) = adapter.delegatecall(
+                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+                return (success, returndata);
+            }
+            // If the `lst` address is blank, no swap is necessary
+            else { 
+                // Encode to the adapter interface
+                bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
+                // Conduct the lend operation to acquire principal tokens
+                (success, returndata) = adapter.delegatecall(
+                    abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
+            }
     }
 
     /// @notice Allows batched call to self (this contract).

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -176,7 +176,7 @@ contract Lender {
         // approve the underlying for max per given principal
         for (uint8 i; i != 9; ) {
             // get the principal token's address
-            address token = IMarketPlace(marketPlace).markets(u, m, i);
+            address token = IMarketPlace(marketPlace).markets(u, m).tokens[i];
             // check that the token is defined for this particular market
             if (token != address(0)) {
                 // max approve the token
@@ -289,7 +289,7 @@ contract Lender {
         uint256 a
     ) external nonReentrant unpaused(u, m, p) returns (bool) {
         // Fetch the desired principal token
-        address principal = IMarketPlace(marketPlace).markets(u, m, p);
+        address principal = IMarketPlace(marketPlace).markets(u, m).tokens[p];
 
         // Disallow mints if market is not initialized
         if (principal == address(0)) {
@@ -513,11 +513,13 @@ contract Lender {
         uint256 m,
         bytes calldata d
     ) external returns (uint256) {
+        IMarketPlace.Market memory _Market = IMarketPlace(marketPlace).markets(u, m);
+
         // Fetch the adapter for this lend call
-        address adapter = IMarketPlace(marketPlace).adapters(u, m, p);
+        address adapter = _Market.adapters[p];
 
         // Fetch the principal token for this lend call
-        address pt = IMarketPlace(marketPlace).markets(u, m, p);
+        address pt = _Market.tokens[p];
 
         // Conduct the lend operation to acquire principal tokens
         (bool success, bytes memory returndata) = adapter.delegatecall(

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -524,6 +524,7 @@ contract Lender {
 
         bytes memory returndata;
         bool success;
+        // If the underlying is WETH, the market is for ETH and `d` contains additional parameters
         if (u == 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2) {
             // Parse the calldata
         (
@@ -535,21 +536,25 @@ contract Lender {
             address lst,
             uint256 swapMinimum
         ) = abi.decode(d, (address, uint256, address, uint256, uint256, address, uint256));
+            // If the "lst" address is populated, a swap is required
             if (lst != address(0)) {
                 amount = ICurveWrapper(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).swap(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2, lst, amount, swapMinimum);
-
+                // Encode to the adapter interface
                 bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
                 // Conduct the lend operation to acquire principal tokens
                 (success, returndata) = adapter.delegatecall(
                     abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
             }
-            else {
+            // If the `lst` address is blank, no swap is necessary
+            else { 
+                // Encode to the adapter interface
                 bytes memory d_ = abi.encode(underlying, maturity, pool, amount, minimum);
                 // Conduct the lend operation to acquire principal tokens
                 (success, returndata) = adapter.delegatecall(
                     abi.encodeWithSignature('lend(bytes calldata inputdata)', d_));
             }
         }
+        // If the underlying is not WETH, no extra swaps or parameters are necessary
         else {
             // Conduct the lend operation to acquire principal tokens
             (success, returndata) = adapter.delegatecall(

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -709,7 +709,7 @@ contract Lender {
     /// @param m maturity (timestamp) of the market
     /// @return address of the ERC5095 token for the market
     function principalToken(address u, uint256 m) internal returns (address) {
-        return IMarketPlace(marketPlace).markets(u, m, 0);
+        return IMarketPlace(marketPlace).markets(u, m).tokens[uint8(MarketPlace.Principals.Illuminate)];
     }
 
     /// @notice converts principal decimal amount to underlying's decimal amount

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -28,7 +28,7 @@ contract YieldAdapter is IAdapter, Lender {
             uint256 minimum
         ) = abi.decode(d, (address, uint256, address, uint256, uint256));
 
-        address pt = IMarketPlace(marketPlace).markets(underlying, maturity, 0);
+        address pt = IMarketPlace(marketPlace).markets(underlying, maturity).tokens[0];
 
         // Receive underlying funds, extract fees
         Safe.transferFrom(

--- a/src/interfaces/ICurveWrapper.sol
+++ b/src/interfaces/ICurveWrapper.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.20;
+
+interface ICurveWrapper {
+    function swap(
+        address from,
+        address to,
+        uint256 amount,
+        uint256 minimum
+    ) external returns (uint256);
+}

--- a/src/interfaces/IMarketPlace.sol
+++ b/src/interfaces/IMarketPlace.sol
@@ -3,11 +3,14 @@
 pragma solidity 0.8.20;
 
 interface IMarketPlace {
-    function markets(address, uint256, uint256) external returns (address);
+    
+    function markets(address, uint256) external returns (Market memory);
 
-    function adapters(address, uint256, uint256) external returns (address);
-
-    function pools(address, uint256) external view returns (address);
+    struct Market {
+        address[] tokens;
+        address[] adapters;
+        address pool;
+    }
 
     function sellPrincipalToken(
         address,


### PR DESCRIPTION
Everything is in a single

```    
struct Market {
        address[] tokens; // The principal tokens array for the market
        address[] adapters; // The adapters array for the market
        address pool; // the illuminate pool address for the market
    }
```

Also added logic to the `lend` method in the Lender that checks if the underlying address is WETH and conditionally does a ETH->X trade by parsing the data object.

In the case of an ETH market that means the data object is expected to have two additional parameters if needing to do a trade.

Instead of:
```
            address underlying,
            uint256 maturity,
            address pool,
            uint256 amount,
            uint256 minimum,
```
You would need to pack:
```
            address underlying,
            uint256 maturity,
            address pool,
            uint256 amount,
            uint256 minimum,
            address lst,
            uint256 swapMinimum
```

