### PR TITLE
add underlying to current adapters

### DIFF
--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -18,6 +18,10 @@ contract SwivelAdapter is IAdapter, Lender {
 
     address public lender = address(0);
 
+    function underlying(address pt) public view returns (address) {
+        return address(IERC5095(pt).underlying());
+    }
+
     function lend(
         bytes calldata d
     ) external authorized(lender) returns (uint256, uint256) {

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -16,6 +16,10 @@ contract YieldAdapter is IAdapter, Lender {
 
     address public lender = address(0);
 
+    function underlying(address pt) public view returns (address) {
+        return address(IYield(pt).base());
+    }
+
     function lend(
         bytes calldata d
     ) external authorized(lender) returns (uint256, uint256) {


### PR DESCRIPTION
Quick PR for demo interface to request `underlying` from an adapter.

This is very easy to implement for all protocols other than Sense. For Sense there can be a conditional check for a given ETH underlying's and if their mapping returns 0x0000... then move to check the next underlying... But thats a pretty shitty workaround IMO so ill investigate more there