### PR TITLE
Eth override

### DIFF
--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -516,6 +516,7 @@ contract Lender {
     /// @param p principal value according to the MarketPlace's Principals Enum
     /// @param u underlying asset address of the market's tuple
     /// @param m timestamp of maturity of the market's tuple
+    /// @param a amount of underlying to lend (an array is used for Swivel lends, [0] is the amount for other cases)
     /// @param d data to conduct the call
     function lend(
         uint8 p,
@@ -551,6 +552,13 @@ contract Lender {
 
     // An override lend method for all ETH lending with the additional lpt and swap parameters
     // This method is only used for lending to ETH markets
+    /// @param p principal value according to the MarketPlace's Principals Enum
+    /// @param u underlying asset address of the market's tuple
+    /// @param m timestamp of maturity of the market's tuple
+    /// @param a amount of underlying to lend (an array is used for Swivel lends, [0] is the amount for other cases)
+    /// @param d data to conduct the call
+    /// @param lst address of the token to swap to
+    /// @param swapMinimum minimum amount of lst to receive
     function lend(
         uint8 p,
         address u,
@@ -631,7 +639,7 @@ contract Lender {
         return (amounts);
     }
 
-    // @notice: Handles all lending to ETH markets and any swaps necessary
+    // @notice: Handles all necessary ETH swaps when lending
     // @param lst: The address of the token to swap to
     // @param amount: The amount of underlying to spend
     // @param swapMinimum: The minimum amount of lst to receive

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -517,14 +517,8 @@ contract Lender {
     ) external returns (uint256) {
         IMarketPlace.Market memory _Market = IMarketPlace(marketPlace).markets(u, m);
 
-        // Fetch the adapter for this lend call
-        address adapter = _Market.adapters[p];
-
-        // Fetch the principal token for this lend call
-        address pt = _Market.tokens[p];
-
         // Conduct the lend operation to acquire principal tokens
-        (bool success, bytes memory returndata) = adapter.delegatecall(
+        (bool success, bytes memory returndata) = _Market.adapters[p].delegatecall(
             abi.encodeWithSignature('lend(uint256[] amount, bytes calldata inputdata)', a, d));
 
         if (!success) {
@@ -538,12 +532,12 @@ contract Lender {
         );
 
         // Convert decimals from principal token to underlying
-        uint256 returned = convertDecimals(u, pt, obtained);
+        uint256 returned = convertDecimals(u, _Market.tokens[p], obtained);
 
         // Mint Illuminate PTs to msg.sender
         IERC5095(principalToken(u, m)).authMint(msg.sender, returned);
         emit Lend(p, u, m, returned, spent, msg.sender);
-        return returned;
+        return (returned);
     }
 
     // An override lend method for all ETH lending with the additional lpt and swap parameters
@@ -559,11 +553,6 @@ contract Lender {
     ) external returns (uint256) {
         IMarketPlace.Market memory _Market = IMarketPlace(marketPlace).markets(u, m);
 
-        // Fetch the adapter for this lend call
-        address adapter = _Market.adapters[p];
-
-        // Fetch the principal token for this lend call
-        address pt = _Market.tokens[p];
         // If the lst parameter is not populated, a swap is not required
         if (lst != address(0)) {
             // If the protocol is not Swivel, send the lent amount as is
@@ -586,7 +575,7 @@ contract Lender {
             }
         }
         // Conduct the lend operation to acquire principal tokens
-        (bool success, bytes memory returndata) = adapter.delegatecall(
+        (bool success, bytes memory returndata) = _Market.adapters[p].delegatecall(
             abi.encodeWithSignature('lend(uint256[] amount, bytes calldata inputdata)', a, d));
         
         if (!success) {
@@ -600,12 +589,12 @@ contract Lender {
         );
 
         // Convert decimals from principal token to underlying
-        uint256 returned = convertDecimals(u, pt, obtained);
+        uint256 returned = convertDecimals(u, _Market.tokens[p], obtained);
 
         // Mint Illuminate PTs to msg.sender
         IERC5095(principalToken(u, m)).authMint(msg.sender, returned);
         emit Lend(p, u, m, returned, spent, msg.sender);
-        return returned;
+        return (returned);
     }
 
     // @notice: Adjusts all Swivel Amounts according to the slippageRatio

--- a/src/MarketPlace.sol
+++ b/src/MarketPlace.sol
@@ -36,7 +36,6 @@ contract MarketPlace {
 
     /// @notice markets are defined by a maturity and underlying tuple that points to an array of principal token addresses.
     mapping(address => mapping(uint256 => Market)) public markets;
-
     /// @notice address that is allowed to create markets, set pools, etc. It is commonly used in the authorized modifier.
     address public admin;
     /// @notice address of the deployed redeemer contract

--- a/src/Redeemer.sol
+++ b/src/Redeemer.sol
@@ -248,10 +248,10 @@ contract Redeemer {
         bytes calldata d
     ) external unpaused(u, m) returns (bool) {
         // Get the principal token that is being redeemed
-        address pt = IMarketPlace(marketPlace).markets(u, m, p);
+        address pt = IMarketPlace(marketPlace).markets(u, m).tokens[p];
 
         // Get the adapter for the protocol being redeemed
-        address adapter = IMarketPlace(marketPlace).adapters(u, m, p);
+        address adapter = IMarketPlace(marketPlace).markets(u, m).adapters[p];
 
         {
             // Verify that the PT has matured
@@ -315,12 +315,8 @@ contract Redeemer {
     function redeem(address u, uint256 m) external unpaused(u, m) {
         // Get Illuminate's principal token for this market
         IERC5095 token = IERC5095(
-            IMarketPlace(marketPlace).markets(
-                u,
-                m,
-                uint8(MarketPlace.Principals.Illuminate)
-            )
-        );
+            IMarketPlace(marketPlace).markets(u, m).adapters[uint8(MarketPlace.Principals.Illuminate)]
+            );
 
         // Verify the token has matured
         if (block.timestamp < token.maturity()) {
@@ -360,12 +356,12 @@ contract Redeemer {
         uint256 a
     )
         external
-        authorized(IMarketPlace(marketPlace).markets(u, m, 0))
+        authorized(IMarketPlace(marketPlace).markets(u, m).tokens[0])
         unpaused(u, m)
         returns (uint256)
     {
         // Get the principal token for the given market
-        IERC5095 pt = IERC5095(IMarketPlace(marketPlace).markets(u, m, 0));
+        IERC5095 pt = IERC5095(IMarketPlace(marketPlace).markets(u, m).tokens[0]);
 
         // Make sure the market has matured
         uint256 maturity = pt.maturity();
@@ -401,7 +397,7 @@ contract Redeemer {
         address[] calldata f
     ) external unpaused(u, m) returns (uint256) {
         // Get the principal token for the given market
-        IERC5095 pt = IERC5095(IMarketPlace(marketPlace).markets(u, m, 0));
+        IERC5095 pt = IERC5095(IMarketPlace(marketPlace).markets(u, m).tokens[0]);
 
         // Make sure the market has matured
         if (block.timestamp < pt.maturity()) {

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -23,11 +23,11 @@ contract SwivelAdapter is IAdapter, Lender {
     }
 
     function lend(
+        uint256[] memory amount,
         bytes calldata d
     ) external authorized(lender) returns (uint256, uint256) {
         // Parse the calldata into the arguments
         (
-            uint256[] memory amounts,
             Swivel.Order[] memory orders,
             Swivel.Components[] memory components,
             address pool,
@@ -36,7 +36,6 @@ contract SwivelAdapter is IAdapter, Lender {
         ) = abi.decode(
                 d,
                 (
-                    uint256[],
                     Swivel.Order[],
                     Swivel.Components[],
                     address,

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -7,6 +7,7 @@ import {ISwivel} from "src/interfaces/ISwivel.sol";
 import {IERC20} from "src/interfaces/IERC20.sol";
 import {IYield} from "src/interfaces/IYield.sol";
 import {IMarketPlace} from "src/interfaces/IMarketPlace.sol";
+import {IERC5095} from "src/interfaces/IERC5095.sol";
 import {Lender} from "src/Lender.sol";
 
 import {Swivel} from "src/lib/Swivel.sol";
@@ -45,15 +46,15 @@ contract SwivelAdapter is IAdapter, Lender {
             );
 
         // Cache a couple oft-referenced variables
-        address underlying = orders[0].underlying;
+        address underlying_ = orders[0].underlying;
         uint256 maturity = orders[0].maturity;
-        address pt = IMarketPlace(marketPlace).markets(underlying, maturity, 1);
+        address pt = IMarketPlace(marketPlace).markets(underlying_, maturity).tokens[1];
 
         // verify orders are for the same underlying
         {
             for (uint256 i = 0; i < orders.length; ) {
                 if (
-                    underlying != orders[i].underlying ||
+                    underlying_ != orders[i].underlying ||
                     maturity != orders[i].maturity
                 ) {
                     revert Exception(0, 0, 0, address(0), address(0)); // TODO: assign exception code
@@ -69,15 +70,15 @@ contract SwivelAdapter is IAdapter, Lender {
         uint256 total;
         uint256 fee;
         {
-            for (uint256 i = 0; i < amounts.length; ) {
-                total += amounts[i];
+            for (uint256 i = 0; i < amount.length; ) {
+                total += amount[i];
 
                 // extract fee
-                if (i == amounts.length - 1) {
+                if (i == amount.length - 1) {
                     fee = total / feenominator;
-                    amounts[i] = amounts[i] - fee;
+                    amount[i] = amount[i] - fee;
                     total = total - fee;
-                    fees[underlying] += fee;
+                    fees[underlying_] += fee;
                 }
 
                 unchecked {
@@ -88,7 +89,7 @@ contract SwivelAdapter is IAdapter, Lender {
 
         // receive the underlying funds from the user
         Safe.transferFrom(
-            IERC20(underlying),
+            IERC20(underlying_),
             msg.sender,
             address(this),
             total + fee
@@ -98,16 +99,16 @@ contract SwivelAdapter is IAdapter, Lender {
         uint256 received = IERC20(pt).balanceOf(address(this));
 
         // execute the orders
-        uint256 premium = IERC20(underlying).balanceOf(address(this));
-        ISwivel(protocolRouters[0]).initiate(orders, amounts, components);
-        premium = IERC20(underlying).balanceOf(address(this)) - premium;
+        uint256 premium = IERC20(underlying_).balanceOf(address(this));
+        ISwivel(protocolRouters[0]).initiate(orders, amount, components);
+        premium = IERC20(underlying_).balanceOf(address(this)) - premium;
         received = IERC20(pt).balanceOf(address(this)) - received;
 
         // Swap the premium for iPTs or return premium to the sender
         if (swapFlag) {
-            received += swap(pool, underlying, premium, slippage);
+            received += swap(pool, underlying_, premium, slippage);
         } else {
-            premiums[underlying][maturity] += premium;
+            premiums[underlying_][maturity] += premium;
             received += premium;
         }
 

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -22,6 +22,7 @@ contract YieldAdapter is IAdapter, Lender {
 
     function lend(
         uint256[] memory amount,
+        bool internalBalance,
         bytes calldata d
     ) external authorized(lender) returns (uint256, uint256) {
         // Parse the calldata
@@ -33,14 +34,15 @@ contract YieldAdapter is IAdapter, Lender {
         ) = abi.decode(d, (address, uint256, uint256, address));
 
         address pt = IMarketPlace(marketPlace).markets(underlying_, maturity).tokens[0];
-
-        // Receive underlying funds, extract fees
-        Safe.transferFrom(
-            IERC20(underlying_),
-            msg.sender,
-            address(this),
-            amount[0]
-        );
+        if (internalBalance == false){
+            // Receive underlying funds, extract fees
+            Safe.transferFrom(
+                IERC20(underlying_),
+                msg.sender,
+                address(this),
+                amount[0]
+            );
+        }
 
         uint256 fee = amount[0] / feenominator;
         fees[underlying_] += fee;

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -11,7 +11,7 @@ import {IMarketPlace} from "../interfaces/IMarketPlace.sol";
 
 import {Safe} from "../lib/Safe.sol";
 
-contract YieldAdapter is IAdapter, Lender {
+contract YieldAdapter is IAdapter, Lender { 
     constructor() Lender(address(0), address(0), address(0)) {}
 
     address public lender = address(0);
@@ -21,16 +21,16 @@ contract YieldAdapter is IAdapter, Lender {
     }
 
     function lend(
+        uint256[] memory amount,
         bytes calldata d
     ) external authorized(lender) returns (uint256, uint256) {
         // Parse the calldata
         (
             address underlying,
             uint256 maturity,
-            address pool,
-            uint256 amount,
-            uint256 minimum
-        ) = abi.decode(d, (address, uint256, address, uint256, uint256));
+            uint256 minimum,
+            address pool
+        ) = abi.decode(d, (address, uint256, uint256, address));
 
         address pt = IMarketPlace(marketPlace).markets(underlying, maturity).tokens[0];
 
@@ -39,18 +39,18 @@ contract YieldAdapter is IAdapter, Lender {
             IERC20(underlying),
             msg.sender,
             address(this),
-            amount
+            amount[0]
         );
 
-        uint256 fee = amount / feenominator;
+        uint256 fee = amount[0] / feenominator;
         fees[underlying] += fee;
 
         // Execute the order
         uint256 starting = IERC20(pt).balanceOf(address(this));
-        Safe.transfer(IERC20(underlying), pool, amount - fee);
+        Safe.transfer(IERC20(underlying), pool, amount[0] - fee);
         IYield(pool).sellBase(address(this), uint128(minimum));
         uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
 
-        return (received, amount);
+        return (received, amount[0]);
     }
 }

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -26,28 +26,28 @@ contract YieldAdapter is IAdapter, Lender {
     ) external authorized(lender) returns (uint256, uint256) {
         // Parse the calldata
         (
-            address underlying,
+            address underlying_,
             uint256 maturity,
             uint256 minimum,
             address pool
         ) = abi.decode(d, (address, uint256, uint256, address));
 
-        address pt = IMarketPlace(marketPlace).markets(underlying, maturity).tokens[0];
+        address pt = IMarketPlace(marketPlace).markets(underlying_, maturity).tokens[0];
 
         // Receive underlying funds, extract fees
         Safe.transferFrom(
-            IERC20(underlying),
+            IERC20(underlying_),
             msg.sender,
             address(this),
             amount[0]
         );
 
         uint256 fee = amount[0] / feenominator;
-        fees[underlying] += fee;
+        fees[underlying_] += fee;
 
         // Execute the order
         uint256 starting = IERC20(pt).balanceOf(address(this));
-        Safe.transfer(IERC20(underlying), pool, amount[0] - fee);
+        Safe.transfer(IERC20(underlying_), pool, amount[0] - fee);
         IYield(pool).sellBase(address(this), uint128(minimum));
         uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
 

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -3,5 +3,6 @@
 pragma solidity 0.8.20;
 
 interface IAdapter {
-    function lend(bytes calldata) external returns (uint256, uint256);
+    function lend(uint256[] calldata, bytes calldata) external returns (uint256, uint256);
+    function underlying(address pt) public view returns (address) 
 }

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -3,6 +3,6 @@
 pragma solidity 0.8.20;
 
 interface IAdapter {
-    function lend(uint256[] calldata, bytes calldata) external returns (uint256, uint256);
+    function lend(uint256[] calldata, bool internalBalance, bytes calldata) external returns (uint256, uint256);
     function underlying(address pt) external view returns (address);
 }

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -4,5 +4,5 @@ pragma solidity 0.8.20;
 
 interface IAdapter {
     function lend(uint256[] calldata, bytes calldata) external returns (uint256, uint256);
-    function underlying(address pt) public view returns (address) 
+    function underlying(address pt) external view returns (address);
 }

--- a/src/interfaces/ICurveWrapper.sol
+++ b/src/interfaces/ICurveWrapper.sol
@@ -8,5 +8,5 @@ interface ICurveWrapper {
         address to,
         uint256 amount,
         uint256 minimum
-    ) external returns (uint256);
+    ) external returns (uint256, uint256);
 }

--- a/src/interfaces/IETHWrapper.sol
+++ b/src/interfaces/IETHWrapper.sol
@@ -2,10 +2,12 @@
 
 pragma solidity 0.8.20;
 
-interface ICurveWrapper {
+interface IETHWrapper {
     function swap(
         address from,
         address to,
+        address fromToken,
+        address toToken,
         uint256 amount,
         uint256 minimum
     ) external returns (uint256, uint256);

--- a/src/interfaces/IETHWrapper.sol
+++ b/src/interfaces/IETHWrapper.sol
@@ -4,8 +4,6 @@ pragma solidity 0.8.20;
 
 interface IETHWrapper {
     function swap(
-        address from,
-        address to,
         address fromToken,
         address toToken,
         uint256 amount,

--- a/src/interfaces/IMarketPlace.sol
+++ b/src/interfaces/IMarketPlace.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.20;
 
 interface IMarketPlace {
     
-    function markets(address, uint256) external returns (Market memory);
+    function markets(address, uint256) external view returns (Market memory);
 
     struct Market {
         address[] tokens;

--- a/src/mocks/MarketPlace.sol
+++ b/src/mocks/MarketPlace.sol
@@ -75,15 +75,14 @@ contract MarketPlace is IMarketPlace {
     /// @dev we want this to return the ipt when the user passes 0 for p
     function markets(
         address u,
-        uint256 m,
-        uint256 p
-    ) external override returns (address) {
-        if (p == 0) {
-            iptCalled[u] = MarketsArgs(m, p);
-            return iptReturn;
-        }
-        marketsCalled[u] = MarketsArgs(m, p);
-        return marketsReturn;
+        uint256 m
+    ) external view override returns (Market memory) {
+        // if (p == 0) {
+        //     iptCalled[u] = MarketsArgs(m, p);
+        //     return iptReturn;
+        // }
+        // marketsCalled[u] = MarketsArgs(m, p);
+        // return marketsReturn;
     }
 
     function adapters(


### PR DESCRIPTION
There are now two `lend` methods.

One covers all "normal" lending -- While the other covers our hybrid staking/lending ETH markets.

The standard lend interface is now:
```
function lend(
        uint8 p,
        address u,
        uint256 m,
        uint256[] memory a,
        bytes calldata d
        )
```
with the eth market interface:
```
function lend(
        uint8 p,
        address u,
        uint256 m,
        uint256[] memory a,
        bytes calldata d,
        address lst,
        uint256 swapMinimum
    )
```

This allows us to have a mutable `a` within a method which is necessary to adjust for slippage on ETH transactions (memory rather than calldata), as well as the generic passing of the bytes `d` to an adapter, and theoverride method specific for any ETH transactions