### PR TITLE
ETH wrapper creation!

### DIFF
--- a/src/ETHWrapper.sol
+++ b/src/ETHWrapper.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity 0.8.20;
+
+import "./lib/Safe.sol";
+import "./errors/Exception.sol";
+
+import "./interfaces/IERC20.sol";
+import "./interfaces/IERC5095.sol";
+import "./interfaces/ICurve.sol";
+
+
+/// @title ETHWrapper
+/// @author Julian Traversa
+/// @notice The contract that wraps ETH into a given lst using curve
+contract ETHWrapper {
+
+    address public eth = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    address public stETH = 0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84;
+    address public stETHPool = 0xDC24316b9AE028F1497c275EB9192a3Ea0f67022;
+    address public frxETH = 0x5E8422345238F34275888049021821E8E08CAa1f;
+    address public frxETHPool = 0xa1F8A6807c402E4A15ef4EBa36528A3FED24E577;
+    address public admin;
+
+    // authorized modifier
+    modifier authorized(address a) {
+        require(msg.sender == a, 'Only an authorized address can call this function');
+        _;
+    }
+
+    constructor() {
+        admin = msg.sender;
+    }
+
+    // Generically approve a contract to spend tokens
+    function approveCurve(address token, address spender) external authorized(admin) {
+        IERC20(token).approve(spender, type(uint256).max);
+    }
+
+    // Sets admin
+    function setAdmin(address a) external authorized(admin) {
+        admin = a;
+    }
+
+    /// @notice convert using Curve Finance
+    /// @notice expects funds already sent to this contract
+    /// @param input address of the token to be spent on Curve
+    /// @param output address of the token to be recieved from Curve
+    /// @param amount amount of input to be spent on Curve
+    /// @param minimum minimum amount of output to be recieved from Curve
+    function swap(
+        address input,
+        address output,
+        uint256 amount,
+        uint256 minimum
+    ) external payable returns (uint256, uint256) {
+        address pool;
+        // if input or output is eth
+        if (input == stETH || output == stETH) {
+            pool == stETHPool;
+        } else {
+            pool == frxETHPool;
+        }
+        // Instantiate Curve and determine Curve pathing
+        ICurve curve = ICurve(pool);
+
+        int128 _input;
+        int128 _output;
+        if (curve.coins(0) == input) {
+            _input = 0;
+            _output = 1;
+        } else {
+            _input = 1;
+            _output = 0;
+        }
+
+        // Swap on curve, spending amount of input, expecting minimumCurve of output
+        // TODO support for Curve v2?
+        uint256 returned = ICurve(pool).exchange(_input, _output, amount, minimum);
+        // TODO: Double check this calculation -- I derived it and checked the outputs on chain but worth a double check
+        // slippageRatio is the denominator necessary to adjust other values to the same scale as the returned value
+        uint256 slippageRatio = 1e18 / ((amount - returned) * 1e18 / amount);
+
+        return (returned, slippageRatio);
+
+    }
+}

--- a/src/ETHWrapper.sol
+++ b/src/ETHWrapper.sol
@@ -57,9 +57,9 @@ contract ETHWrapper {
         address pool;
         // if input or output is eth
         if (input == stETH || output == stETH) {
-            pool == stETHPool;
+            pool = stETHPool;
         } else {
-            pool == frxETHPool;
+            pool = frxETHPool;
         }
         // Instantiate Curve and determine Curve pathing
         ICurve curve = ICurve(pool);

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -382,6 +382,11 @@ contract Lender {
         // Reset accumulated fees of the token to 0
         fees[e] = 0;
 
+        if (e == WETH) {
+            // transfer eth
+            payable(admin).transfer(address(this).balance);
+        }
+        
         // Transfer the accumulated fees to the admin
         Safe.transfer(token, admin, balance);
 

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -586,6 +586,7 @@ contract Lender {
                     }
                 }
                 spent = total;
+                require (msg.value >= total, 'Insufficient ETH');
                 (, uint256 slippageRatio) = SwapETH(lst, total, swapMinimum);
                 a = adjustSwivelAmounts(a, slippageRatio);
             }
@@ -594,6 +595,7 @@ contract Lender {
                 (uint256 lent, ) = SwapETH(lst, a[0], swapMinimum);
                 spent = a[0];
                 a[0] = lent;
+                require (msg.value >= spent, 'Insufficient ETH');
             }
             // Conduct the lend operation to acquire principal tokens
             (success, returndata) = _Market.adapters[p].delegatecall(

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -632,7 +632,7 @@ contract Lender {
     // @returns The adjusted amount array
     function adjustSwivelAmounts(uint256[] memory amounts, uint256 slippageRatio) internal pure returns (uint256[] memory) {
         for (uint256 i; i != amounts.length; ) {
-            amounts[i] = amounts[i] - amounts[i] * slippageRatio;
+            amounts[i] = amounts[i] - amounts[i] / slippageRatio;
             unchecked {
                 ++i;
             }

--- a/src/interfaces/ICurve.sol
+++ b/src/interfaces/ICurve.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.20;
+
+interface ICurve {
+    function exchange(
+        int128,
+        int128,
+        uint256,
+        uint256
+    ) external returns (uint256);
+
+    function get_dy(int128, int128, uint256) external returns (uint256);
+
+    function coins(int128) external returns (address);
+}
+
+interface ICurveV2 {
+    function exchange(
+        address,
+        address,
+        address,
+        uint256,
+        uint256,
+        address
+    ) external payable returns (uint256);
+
+    function exchange_with_best_rate(
+        address,
+        address,
+        address,
+        uint256,
+        uint256,
+        address
+    ) external payable returns (uint256);
+}

--- a/src/interfaces/IETHWrapper.sol
+++ b/src/interfaces/IETHWrapper.sol
@@ -4,10 +4,8 @@ pragma solidity 0.8.20;
 
 interface IETHWrapper {
     function swap(
-        address from,
-        address to,
-        address fromToken,
-        address toToken,
+        address input,
+        address output,
         uint256 amount,
         uint256 minimum
     ) external returns (uint256, uint256);

--- a/src/interfaces/IETHWrapper.sol
+++ b/src/interfaces/IETHWrapper.sol
@@ -2,10 +2,12 @@
 
 pragma solidity 0.8.20;
 
-interface ICurveWrapper {
+interface IETHWrapper {
     function swap(
         address from,
         address to,
+        address fromToken,
+        address toToken,
         uint256 amount,
         uint256 minimum
     ) external returns (uint256, uint256);


### PR DESCRIPTION
The swap method is currently implemented to cover all potential swaps between frxETH<>ETH and stETH<>ETH.

I may create a mapping of addresses -> pools that we can populate with a setter, allowing it to be more generic. 

The method is pretty straightforward. 
1. Identify the pool by the token traded 
2. Identify the token index
3. Do the swap
4. Calculate the `slippageRatio`

I'd appreciate a quick double check / sanity check on the `slippageRatio` calculation -- I kind of derived it by intuition but it seems to be correct. The value returned by this math allows you to use it as a denominator to adjust values.

Example use of the result: `adjustedValue = value - (value / slippageRatio)`