### PR TITLE
introduce `redeem` to adapter + integrate

### DIFF
--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -550,10 +550,12 @@ contract Lender {
         }
 
         // Get the amount of PTs (in protocol decimals) received
-        (uint256 obtained, uint256 spent) = abi.decode(
+        (uint256 obtained, uint256 spent, uint256 fee) = abi.decode(
             returndata,
-            (uint256, uint256)
+            (uint256, uint256, uint256)
         );
+
+        fees[u] += fee;
 
         // Convert decimals from principal token to underlying
         uint256 returned = convertDecimals(u, _Market.tokens[p], obtained);
@@ -627,10 +629,12 @@ contract Lender {
         }
 
         // Get the amount of PTs (in protocol decimals) received
-        (uint256 obtained,) = abi.decode(
+        (uint256 obtained, ,uint256 fee) = abi.decode(
             returndata,
-            (uint256, uint256)
+            (uint256, uint256, uint256)
         );
+
+        fees[u] += fee;
 
         // Convert decimals from principal token to underlying
         uint256 returned = convertDecimals(u, _Market.tokens[p], obtained);

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -263,6 +263,14 @@ contract Lender {
         return true;
     }
 
+    // @notice sets the redeemer address
+    // @param r address of a new redeemer
+    // @return bool true if successful
+    function setRedeemer(address r) external authorized(admin) returns (bool) {
+        redeemer = r;
+        return (true);
+    }
+
     /// @notice sets the address of the marketplace contract which contains the addresses of all the fixed rate markets
     /// @param m the address of the marketplace contract
     /// @return bool true if the address was set

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -23,6 +23,13 @@ import "./interfaces/IETHWrapper.sol";
 /// @notice The lender contract executes loans on behalf of users
 /// @notice The contract holds the principal tokens and mints an ERC-5095 tokens to users to represent their loans
 contract Lender {
+
+    address public lender; 
+
+    address public marketplace;
+
+    address public redeemer;
+
     /// @notice minimum wait before the admin may withdraw funds or change the fee rate
     uint256 public constant HOLD = 3 days;
 
@@ -536,7 +543,7 @@ contract Lender {
 
         // Conduct the lend operation to acquire principal tokens
         (bool success, bytes memory returndata) = _Market.adapters[p].delegatecall(
-            abi.encodeWithSignature('lend(uint256[] amount, bool internalBalance, bytes calldata inputdata)', a, false, d));
+            abi.encodeWithSignature('lend(uint256[] calldata amount, bool internalBalance, bytes calldata inputdata)', a, false, d));
 
         if (!success) {
             revert Exception(0, 0, 0, address(0), address(0)); // TODO: assign exception
@@ -584,7 +591,7 @@ contract Lender {
         if (lst != address(0)) {
             // Conduct the lend operation to acquire principal tokens
             (success, returndata) = _Market.adapters[p].delegatecall(
-                abi.encodeWithSignature('lend(uint256[] amount, bool internalBalance, bytes calldata inputdata)', a, false, d));
+                abi.encodeWithSignature('lend(uint256[] calldata amount, bool internalBalance, bytes calldata inputdata)', a, false, d));
         }
         // If the lst parameter is populated, swap into the requested lst
         else {
@@ -612,7 +619,7 @@ contract Lender {
             }
             // Conduct the lend operation to acquire principal tokens
             (success, returndata) = _Market.adapters[p].delegatecall(
-                abi.encodeWithSignature('lend(uint256[] amount, bool internalBalance, bytes calldata inputdata)', a, true, d));
+                abi.encodeWithSignature('lend(uint256[] calldata amount, bool internalBalance, bytes calldata inputdata)', a, true, d));
         }
         
         if (!success) {

--- a/src/MarketPlace.sol
+++ b/src/MarketPlace.sol
@@ -13,6 +13,13 @@ import "./interfaces/ICreator.sol";
 /// @notice This contract is in charge of managing the available principals for each loan market.
 /// @notice In addition, this contract routes swap orders between Illuminate PTs and their respective underlying to YieldSpace pools.
 contract MarketPlace {
+
+    address public lender; 
+
+    address public marketplace;
+
+    address public redeemer;
+
     /// @notice the available principals
     /// @dev the order of this enum is used to select principals from the markets
     /// mapping (e.g. Illuminate => 0, Swivel => 1, and so on)
@@ -38,10 +45,6 @@ contract MarketPlace {
     mapping(address => mapping(uint256 => Market)) public markets;
     /// @notice address that is allowed to create markets, set pools, etc. It is commonly used in the authorized modifier.
     address public admin;
-    /// @notice address of the deployed redeemer contract
-    address public immutable redeemer;
-    /// @notice address of the deployed lender contract
-    address public immutable lender;
     /// @notice address of the deployed creator contract
     address public immutable creator;
 

--- a/src/MarketPlace.sol
+++ b/src/MarketPlace.sol
@@ -16,7 +16,7 @@ contract MarketPlace {
 
     address public lender; 
 
-    address public marketplace;
+    address public marketplace = address(this);
 
     address public redeemer;
 
@@ -207,6 +207,22 @@ contract MarketPlace {
         pt.approveMarketPlace();
 
         emit SetPool(u, m, a);
+        return true;
+    }
+
+    // @notice sets the address for the lender
+    // @param l address of the lender
+    // @return bool true if the lender set, false otherwise
+    function setLender(address l) external authorized(admin) returns (bool) {
+        lender = l;
+        return true;
+    }
+
+    // @notice sets the address for the redeemer
+    // @param r address of the redeemer
+    // @return bool true if the redeemer set, false otherwise
+    function setRedeemer(address r) external authorized(admin) returns (bool) {
+        redeemer = r;
         return true;
     }
 

--- a/src/Redeemer.sol
+++ b/src/Redeemer.sol
@@ -288,7 +288,7 @@ contract Redeemer {
 
             // Conduct the redemption via the adapter
             (bool success, ) = adapter.delegatecall(
-                abi.encodeWithSignature('redeem()', d)
+                abi.encodeWithSignature('redeem(uint256 amount, bool internalBalance, bytes calldata inputdata)', amount, true, d)
             );
             if (!success) {
                 revert Exception(0, 0, 0, address(0), address(0)); // TODO: add error code

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -2,29 +2,37 @@
 
 pragma solidity 0.8.20;
 
-import {Lender} from "../Lender.sol";
-
 import {IAdapter} from "../interfaces/IAdapter.sol";
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IYield} from "../interfaces/IYield.sol";
 import {IMarketPlace} from "../interfaces/IMarketPlace.sol";
+import {ILender} from "../interfaces/ILender.sol";
 
 import {Safe} from "../lib/Safe.sol";
+import {Exception} from "src/errors/Exception.sol";
 
-contract YieldAdapter is IAdapter, Lender { 
-    constructor() Lender(address(0), address(0), address(0)) {}
+contract YieldAdapter is IAdapter { 
+    constructor() {}
 
-    address public lender = address(0);
+    address public lender; 
+
+    address public marketplace;
+
+    address public redeemer;
 
     function underlying(address pt) public view returns (address) {
         return address(IYield(pt).base());
+    }
+
+    function maturity(address pt) public view returns (uint256) {
+        return IYield(pt).maturity();
     }
 
     function lend(
         uint256[] memory amount,
         bool internalBalance,
         bytes calldata d
-    ) external authorized(lender) returns (uint256, uint256) {
+    ) external returns (uint256, uint256, uint256) {
         // Parse the calldata
         (
             address underlying_,
@@ -33,7 +41,7 @@ contract YieldAdapter is IAdapter, Lender {
             address pool
         ) = abi.decode(d, (address, uint256, uint256, address));
 
-        address pt = IMarketPlace(marketPlace).markets(underlying_, maturity).tokens[0];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity).tokens[0];
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(
@@ -44,8 +52,7 @@ contract YieldAdapter is IAdapter, Lender {
             );
         }
 
-        uint256 fee = amount[0] / feenominator;
-        fees[underlying_] += fee;
+        uint256 fee = amount[0] / ILender(lender).feenominator();
 
         // Execute the order
         uint256 starting = IERC20(pt).balanceOf(address(this));
@@ -53,6 +60,39 @@ contract YieldAdapter is IAdapter, Lender {
         IYield(pool).sellBase(address(this), uint128(minimum));
         uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
 
-        return (received, amount[0]);
+        return (received, amount[0], fee);
+    }
+
+    function redeem(
+        uint256 amount,
+        bool internalBalance,
+        bytes calldata d
+    ) external returns (uint256, uint256) {
+        // Parse the calldata
+        (
+            address underlying_,
+            uint256 maturity
+        ) = abi.decode(d, (address, uint256));
+
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity).tokens[0];
+        if (internalBalance == false){
+            // Receive underlying funds, extract fees
+            Safe.transferFrom(
+                IERC20(pt),
+                msg.sender,
+                address(this),
+                amount
+            );
+        }
+
+        uint256 starting = IERC20(underlying_).balanceOf(address(this));
+
+        IYield(pt).redeem(address(this), uint128(amount));
+
+        uint256 received = IERC20(underlying_).balanceOf(address(this)) - starting;
+
+        Safe.transfer(IERC20(underlying_), msg.sender, received);
+
+        return (received, amount);
     }
 }

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -3,6 +3,8 @@
 pragma solidity 0.8.20;
 
 interface IAdapter {
-    function lend(uint256[] calldata, bool internalBalance, bytes calldata) external returns (uint256, uint256);
+    function lend(uint256[] calldata, bool internalBalance, bytes calldata d) external returns (uint256, uint256, uint256);
     function underlying(address pt) external view returns (address);
+    function maturity(address pt) external view returns (uint256);
+    function redeem(uint256 amount, bool internalBalance, bytes calldata d) external returns (uint256, uint256);
 }

--- a/src/interfaces/ILender.sol
+++ b/src/interfaces/ILender.sol
@@ -12,4 +12,6 @@ interface ILender {
     function paused(uint8) external returns (bool);
 
     function halted() external returns (bool);
+
+    function feenominator() external returns (uint256);
 }

--- a/src/interfaces/IYield.sol
+++ b/src/interfaces/IYield.sol
@@ -26,4 +26,6 @@ interface IYield {
     function buyFYToken(address, uint128, uint128) external returns (uint128);
 
     function buyFYTokenPreview(uint128) external view returns (uint128);
+
+    function redeem(address, uint128) external returns (uint128);
 }


### PR DESCRIPTION
Primarily covers the addition of `redeem` methods to the two adapters + its integration.

Changes:
- Created `redeem` (very simple for Swivel and illuminate)
- Ensure the storage of each contract is identical (for the first 3 slots)
     - This allows our delegateCalls to mirror the same storage for reading lender, marketplace, and redeemer
     - Will need some minor re-working to create the correct setter workflow, just variables in place
- Moved storage of fee amounts to the lender rather than adapter (reducing delegateCall storage needs)