### PR TITLE
Stateless ETHWrapper (proxy)

### DIFF
--- a/script/FederationDeployer.s.sol
+++ b/script/FederationDeployer.s.sol
@@ -25,18 +25,17 @@ contract IlluminateFederationDeployer is Script {
         // Deploy contracts
         Creator creator = new Creator();
         Lender lender = new Lender(swivel, pendle, apwine);
-        Redeemer redeemer = new Redeemer(address(lender), swivel, tempus);
+        Redeemer redeemer = new Redeemer(address(lender));
         MarketPlace marketplace = new MarketPlace(
             address(redeemer),
             address(lender),
             address(creator)
-        );
+        ); 
 
         // Call basic setters
         creator.setMarketPlace(address(marketplace));
         lender.setMarketPlace(address(marketplace));
         redeemer.setMarketPlace(address(marketplace));
-        redeemer.setConverter(address(converter), new address[](0));
 
         // Set the admin
         if (admin != address(0)) {

--- a/script/FederationDeployer.s.sol
+++ b/script/FederationDeployer.s.sol
@@ -6,7 +6,6 @@ import 'forge-std/Script.sol';
 import {Lender} from 'src/Lender.sol';
 import {MarketPlace} from 'src/MarketPlace.sol';
 import {Redeemer} from 'src/Redeemer.sol';
-import {Converter} from 'src/Converter.sol';
 import {Creator} from 'src/Creator.sol';
 
 contract IlluminateFederationDeployer is Script {
@@ -32,7 +31,6 @@ contract IlluminateFederationDeployer is Script {
             address(lender),
             address(creator)
         );
-        Converter converter = new Converter();
 
         // Call basic setters
         creator.setMarketPlace(address(marketplace));

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -578,6 +578,7 @@ contract Lender {
     /// @param m timestamp of maturity of the market's tuple
     /// @param a amount of underlying to lend (an array is used for Swivel lends, [0] is the amount for other cases)
     /// @param d data to conduct the call -- For explicit information see a respective adapter's `lendABI` returns
+    /// @param pool address of the pool to swap against
     /// @param lst address of the token to swap to
     /// @param swapMinimum minimum amount of lst to receive
     function lend(
@@ -586,6 +587,7 @@ contract Lender {
         uint256 m,
         uint256[] memory a,
         bytes calldata d,
+        address pool,
         address lst,
         uint256 swapMinimum
     ) external payable returns (uint256) {
@@ -614,12 +616,12 @@ contract Lender {
                 }
                 spent = total;
                 require (msg.value >= total, 'Insufficient ETH');
-                (, uint256 slippageRatio) = swapETH(lst, total, swapMinimum);
+                (, uint256 slippageRatio) = swapETH(pool, lst, total, swapMinimum);
                 a = adjustSwivelAmounts(a, slippageRatio);
             }
             // If the protocol is not Swivel, swap the input `a[0]` and overwrite a[0] with the returned lend amount
             else {
-                (uint256 lent, ) = swapETH(lst, a[0], swapMinimum);
+                (uint256 lent, ) = swapETH(pool, lst, a[0], swapMinimum);
                 spent = a[0];
                 a[0] = lent;
                 require (msg.value >= spent, 'Insufficient ETH');
@@ -670,16 +672,19 @@ contract Lender {
     // @param swapMinimum: The minimum amount of lst to receive
     // @returns lent: The amount of underlying to be lent
     // @returns slippageRatio: The slippageRatio of the swap (1e18 based % to adjust swivel orders if necessary)
-    function swapETH(address lst, uint256 amount, uint256 swapMinimum) internal returns (uint256 lent, uint256 slippageRatio) {
-        payable(ETHWrapper).transfer(amount);
-        if (lst != address(0)) {
-            (lent, slippageRatio)  = IETHWrapper(ETHWrapper).swap(WETH, lst, amount, swapMinimum);
-            return (lent, slippageRatio);
+    function swapETH(address pool, address lst, uint256 amount, uint256 swapMinimum) internal returns (uint256 lent, uint256 slippageRatio) {
+        // Conduct the lend operation to acquire principal tokens
+        (bool success, bytes memory returndata) = ETHWrapper.delegatecall(
+            abi.encodeWithSignature('swap(address,address,address,uint256,uint256)', pool, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", lst, amount, swapMinimum));
+
+        if (!success) {
+            revert Exception(0, 0, 0, address(0), address(0)); // TODO: assign exception
         }
-        // If the `lst` address is blank, no swap is necessary
-        else {
-            return (amount, 1);
-        }
+
+        // Get the amount of PTs (in protocol decimals) received
+        (lent, slippageRatio) = abi.decode(returndata,(uint256, uint256));
+
+        return (lent, slippageRatio);
     }
 
     /// @notice Allows batched call to self (this contract).

--- a/src/Redeemer.sol
+++ b/src/Redeemer.sol
@@ -247,23 +247,27 @@ contract Redeemer {
     }
 
     // @notice: Handles all necessary ETH conversion when redeeming a LST rather than direct ETH
+    // @param pool: The address of the pool to swap to
     // @param lst: The address of the token to swap to
     // @param amount: The amount of underlying to spend
     // @param swapMinimum: The minimum amount of lst to receive
     // @returns lent: The amount of underlying to be lent
     // @returns slippageRatio: The slippageRatio of the swap (1e18 based % to adjust swivel orders if necessary)
-    function convert(address lst, uint256 amount, uint256 swapMinimum) external authorized(admin) returns (uint256 lent, uint256 slippageRatio) {
-        // TODO: convert ETHWrapper to stateless proxy calls
+    function convert(address pool, address lst, uint256 amount, uint256 swapMinimum) external authorized(admin) returns (uint256 returned, uint256 slippageRatio) {
         address ETHWrapper = ILender(lender).ETHWrapper();
-        Safe.transferFrom(IERC20(lst), ETHWrapper, address(this), amount);
-        if (lst != address(0)) {
-            (lent, slippageRatio)  = IETHWrapper(ETHWrapper).swap(lst, ILender(lender).WETH(), amount, swapMinimum);
-            return (lent, slippageRatio);
+
+        // Conduct the lend operation to acquire principal tokens
+        (bool success, bytes memory returndata) = ETHWrapper.delegatecall(
+            abi.encodeWithSignature('swap(address,address,address,uint256,uint256)', pool, lst, "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE", amount, swapMinimum));
+
+        if (!success) {
+            revert Exception(0, 0, 0, address(0), address(0)); // TODO: assign exception
         }
-        // If the `lst` address is blank, no swap is necessary
-        else {
-            revert Exception(0, 0, 0, address(0), address(0)); // TODO: add error code
-        }
+
+        // Get the amount of PTs (in protocol decimals) received
+        (returned, slippageRatio) = abi.decode(returndata,(uint256, uint256));
+
+        return (returned, slippageRatio);
     }
 
     /// @notice redeems principal tokens held by the Lender contract via its adapter

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -58,6 +58,7 @@ contract SwivelAdapter is IAdapter {
     function redeemABI(
     ) public pure {
     }
+    
     // @notice lends `amount` to Swivel protocol by spending `Sum(amount)-Totalfee` on PTs
     // @param amount The amount of the underlying token to lend (an array of amounts that corrosponds with the array of orders in `d`)
     // @param internalBalance Whether or not to use the internal balance or if a transfer is necessary
@@ -172,7 +173,7 @@ contract SwivelAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256) {
 
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity).tokens[0];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[0];
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(

--- a/src/test/swivel.t.sol
+++ b/src/test/swivel.t.sol
@@ -5,7 +5,6 @@ import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 // import all major contracts
-import "../Converter.sol";
 import "../Lender.sol";
 import "../Creator.sol";
 import "../ETHWrapper.sol";
@@ -35,7 +34,6 @@ contract SwivelTest is Test {
     uint256 startingBalance = 100000 ether;
 
     Creator creator;
-    Converter converter;
     ETHWrapper ethWrapper;
     Lender lender;
     Redeemer redeemer;

--- a/src/test/swivel.t.sol
+++ b/src/test/swivel.t.sol
@@ -43,10 +43,9 @@ contract SwivelTest is Test {
 
         // Deploy all major contracts
         creator = new Creator();
-        converter = new Converter();
         ethWrapper = new ETHWrapper();
         lender = new Lender(swivel, address(0), address(0));
-        redeemer = new Redeemer(address(lender), address(0), address(0));
+        redeemer = new Redeemer(address(lender));
         marketplace = new MarketPlace(address(redeemer), address(lender), address(creator));
 
         // Set up connections

--- a/src/test/yield.t.sol
+++ b/src/test/yield.t.sol
@@ -38,10 +38,9 @@ contract YieldTest is Test {
 
         // Deploy all major contracts
         creator = new Creator();
-        converter = new Converter();
         ethWrapper = new ETHWrapper(); 
         lender = new Lender(address(0), address(0), address(0));
-        redeemer = new Redeemer(address(lender), address(0), address(0));
+        redeemer = new Redeemer(address(lender));
         marketplace = new MarketPlace(address(redeemer), address(lender), address(creator));
 
         // Set up connections

--- a/src/test/yield.t.sol
+++ b/src/test/yield.t.sol
@@ -5,7 +5,6 @@ import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 // import all major contracts
-import "../Converter.sol";
 import "../Lender.sol";
 import "../Creator.sol";
 import "../ETHWrapper.sol";
@@ -29,7 +28,6 @@ contract YieldTest is Test {
     uint256 startingBalance = 100000 ether;
 
     Creator creator;
-    Converter converter;
     ETHWrapper ethWrapper;
     Lender lender;
     Redeemer redeemer;


### PR DESCRIPTION
This should save on some gas costs by removing 2 token transfers per ETH lend call 😎 

But the caveat is that it requires the frontend to take the burden of knowing the state -- knowing what pool to transact against for a given LST.

So im open to commentary there and changing things slightly or thinking of a way to have that state mirrored on the redeemer and lender

Edit: 
Also some minor test fixes -- Primarily changes are on the ETHWrapper and the ETH method on redeemer/lender respectively