### PR TITLE
simplify lender -> redeemer approvals (include within setPrincipal an…

### DIFF
--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -226,6 +226,24 @@ contract Lender {
         return (true);
     }
 
+    /// @notice bulk approves the usage of addresses at the given ERC20 addresses.
+    /// @dev the lengths of the inputs must match because the arrays are paired by index
+    /// @param pt array of PT addresses that will be approved on
+    /// @return true if successful
+    function principalApprove(
+        address[] calldata pt
+    ) external authorized(marketplace) returns (bool) {
+        for (uint256 i; i != pt.length; ) {
+            IERC20 uToken = IERC20(pt[i]);
+            if (address(0) != (address(uToken))) {
+                Safe.approve(uToken, redeemer, type(uint256).max);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        return (true);
+    }
     // @notice Enables a given external protocol PT for minting should multiple be needed for a single protocol's market & underlying
     // @notice For example, for Term which has multiple maturities per asset, all enabled PTs will be mintable
     // @param u address of a target PT to enable for minting

--- a/src/Lender.sol
+++ b/src/Lender.sol
@@ -519,7 +519,7 @@ contract Lender {
 
         // Conduct the lend operation to acquire principal tokens
         (,bytes memory returndata) = IMarketPlace(marketplace).adapters(p).delegatecall(
-            abi.encodeWithSignature('mint(address,uint256,uint8)', u, m, p, t, a));
+            abi.encodeWithSignature('mint(address,uint256,uint8,uint256)', u, m, t, a));
 
         // Decode the returndata to get a mintable amount of PTs
         uint256 mintable = abi.decode(returndata, (uint256));

--- a/src/MarketPlace.sol
+++ b/src/MarketPlace.sol
@@ -263,27 +263,6 @@ contract MarketPlace {
         return (true);
     }
 
-    /// @notice approves any necessary addresses
-    /// @param u address of an underlying asset
-    /// @param m maturity (timestamp) of the market
-    /// @param p index of the protocol's adapter
-    /// @return bool true if approvals occurred, false if not
-    function approve(
-        address u,
-        uint256 m,
-        uint8 p
-    ) external authorized(admin) returns (bool) {
-        address adapter = adapters[p];
-
-        if (adapter == address(0)) {
-            revert Exception(0, 0, 0, address(0), address(0));
-        }
-
-        Safe.approve(IERC20(u), adapter, type(uint256).max);
-
-        return (true);
-    }
-
     /// @notice sells the PT for the underlying via the pool
     /// @param u address of an underlying asset
     /// @param m maturity (timestamp) of the market

--- a/src/Redeemer.sol
+++ b/src/Redeemer.sol
@@ -166,7 +166,7 @@ contract Redeemer {
                 address(0)
             );
             // Check the the new fee rate is not too high
-        } else if (f < MIN_FEENOMINATOR) {
+        } else if (f < minimumFeenominator) {
             revert Exception(25, 0, 0, address(0), address(0));
         }
 
@@ -183,7 +183,7 @@ contract Redeemer {
     /// @notice allows the admin to schedule a change to the fee denominators
     function scheduleFeeChange() external authorized(admin) returns (bool) {
         // Calculate the timestamp that must be passed prior to setting thew new fee
-        uint256 when = block.timestamp + HOLD;
+        uint256 when = block.timestamp + hold;
 
         // Store the timestamp that must be passed to update the fee rate
         feeChange = when;

--- a/src/adapters/Base5095Adapter.sol
+++ b/src/adapters/Base5095Adapter.sol
@@ -39,6 +39,11 @@ contract TermAdapter is IAdapter {
         return IERC5095(pt).maturity();
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
     // @returns minimum The minimum amount of the PTs to receive when spending (amount - fee)
     // @returns pool The address of the pool to lend to (buy PTs from)
@@ -54,21 +59,19 @@ contract TermAdapter is IAdapter {
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {
@@ -134,7 +137,7 @@ contract TermAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256) {
         // TODO: Double check protocol enum
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[7];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
         
         if (internalBalance == false){
             // Receive underlying funds, extract fees

--- a/src/adapters/ExactlyAdapter.sol
+++ b/src/adapters/ExactlyAdapter.sol
@@ -42,7 +42,7 @@ contract ExactlyAdapter is IAdapter {
 
     // @notice returns the protocol enum of this given adapter
     function protocol() public view returns (uint8) {
-        return (0);
+        return (10);
     }
 
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function

--- a/src/adapters/ExactlyAdapter.sol
+++ b/src/adapters/ExactlyAdapter.sol
@@ -13,7 +13,7 @@ import {Exception} from "../errors/Exception.sol";
 
 import {Safe} from "../lib/Safe.sol";
 
-contract ExactlyAdapter is IAdapter { 
+contract ExactlyAdapter is IAdapter {
     constructor() {}
 
     address public lender; 
@@ -40,6 +40,11 @@ contract ExactlyAdapter is IAdapter {
         return IERC5095(pt).maturity();
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
     // @returns exactlyMaturity The maturity of the underlying exactly market
     // @returns minimumAssets The minimum amount of the PTs to receive when spending (amount - fee)
@@ -58,21 +63,19 @@ contract ExactlyAdapter is IAdapter {
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {
@@ -130,7 +133,7 @@ contract ExactlyAdapter is IAdapter {
             uint256 minimumAssets // note: This could be removed and just calculated at near par? should be 1:1 or more at maturity and this accounts for prematurity redeems
         ) = abi.decode(d, (uint256, uint256));
         
-        address exactlyToken = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[1];
+        address exactlyToken = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         if (internalBalance == false){
             // Receive underlying funds, extract fees
@@ -165,7 +168,7 @@ contract ExactlyAdapter is IAdapter {
             uint256 exactlyMaturity
         ) = abi.decode(d, (uint256));
 
-        address exactlyToken = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[1];
+        address exactlyToken = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
         
         if (internalBalance == false){
             // Receive underlying funds, extract fees

--- a/src/adapters/IlluminateAdapter.sol
+++ b/src/adapters/IlluminateAdapter.sol
@@ -12,7 +12,7 @@ import {Exception} from "../errors/Exception.sol";
 
 import {Safe} from "../lib/Safe.sol";
 
-contract YieldAdapter is IAdapter { 
+contract IlluminateAdapter is IAdapter { 
     constructor() {}
 
     address public lender; 

--- a/src/adapters/IlluminateAdapter.sol
+++ b/src/adapters/IlluminateAdapter.sol
@@ -4,16 +4,15 @@ pragma solidity 0.8.20;
 
 import {IAdapter} from "../interfaces/IAdapter.sol";
 import {IERC20} from "../interfaces/IERC20.sol";
-import {IERC5095} from "../interfaces/IERC5095.sol";
+import {IYield} from "../interfaces/IYield.sol";
 import {IMarketPlace} from "../interfaces/IMarketPlace.sol";
 import {ILender} from "../interfaces/ILender.sol";
-import {ITermToken, ITermRepoRedeemer} from "../interfaces/ITerm.sol";
 
-import {Exception} from "../errors/Exception.sol";
+import {Exception} from "../errors/Exception.sol"; 
 
 import {Safe} from "../lib/Safe.sol";
 
-contract TermAdapter is IAdapter {
+contract YieldAdapter is IAdapter { 
     constructor() {}
 
     address public lender; 
@@ -31,18 +30,18 @@ contract TermAdapter is IAdapter {
     // @notice returns the address of the underlying token for the PT
     // @param pt The address of the PT
     function underlying(address pt) public view returns (address) {
-         return (ITermToken(pt).config().purchaseToken);
+        return address(IYield(pt).base());
     }
 
     // @notice returns the maturity of the underlying token for the PT
     // @param pt The address of the PT
     function maturity(address pt) public view returns (uint256) {
-        return (ITermToken(pt).config().redemptionTimestamp);
+        return IYield(pt).maturity();
     }
 
     // @notice returns the protocol enum of this given adapter
     function protocol() public view returns (uint8) {
-        return (9);
+        return (0);
     }
 
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
@@ -55,12 +54,10 @@ contract TermAdapter is IAdapter {
     }
 
     // @notice redeemABI "returns" the arguments required in the bytes `d` for the redeem function
-    // @returns targetRedeemer The address of the redeemer for the provided target term repo token TODO: ensure each TermRepoToken has a unique redeemer
-    // @returns targetToken The address of the token to be redeemed
+    // @returns underlying_ The address of the underlying token
+    // @returns maturity The maturity of the underlying token
     function redeemABI(
-    ) public pure returns (
-        address targetRedeemer,
-        address targetToken) {
+    ) public pure {
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
@@ -94,15 +91,12 @@ contract TermAdapter is IAdapter {
         }
         // If the targetToken is not the same as the market PT, validate the underlying and maturity
         if (targetToken != pt) {
-            // Get the token config
-            ITermToken.TermRepoTokenConfig memory config = ITermToken(targetToken).config();
-
-            if (config.purchaseToken != underlying_ || config.redemptionTimestamp > maturity_ || ILender(lender).validToken(targetToken) == false) {
+            if (underlying(targetToken) != underlying_ || maturity(targetToken) > maturity_ || ILender(lender).validToken(targetToken) == false) {
                 revert Exception(
                     8,
-                    config.redemptionTimestamp,
+                    maturity(targetToken),
                     maturity_,
-                    config.purchaseToken,
+                    underlying(targetToken),
                     underlying_
                 );
             }
@@ -127,12 +121,36 @@ contract TermAdapter is IAdapter {
         bool internalBalance,
         bytes calldata d
     ) external returns (uint256, uint256, uint256) {
-        revert Exception(99, 0, 0, address(0), address(0));
+
+        // Parse the calldata
+        (
+            uint256 minimum,
+            address pool
+        ) = abi.decode(d, (uint256, address));
+
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()]; // TODO: get yield PT enum
+        if (internalBalance == false){
+            // Receive underlying funds, extract fees
+            Safe.transferFrom(
+                IERC20(underlying_),
+                msg.sender,
+                address(this),
+                amount[0]
+            );
+        }
+
+        uint256 fee = amount[0] / ILender(lender).feenominator();
+
+        // Execute the order
+        uint256 starting = IERC20(pt).balanceOf(address(this));
+        Safe.transfer(IERC20(underlying_), pool, amount[0] - fee);
+        IYield(pool).sellBase(address(this), uint128(minimum));
+        uint256 received = IERC20(pt).balanceOf(address(this)) - starting;
+
+        return (received, amount[0], fee);
     }
 
-    // @notice After maturity, redeem `amount` of the underlying token from the X protocol
-    // @param underlying_ The address of the underlying token
-    // @param maturity_ The maturity of the underlying token
+    // @notice After maturity, redeem `amount` of the underlying token from the yield protocol
     // @param amount The amount of the PTs to redeem
     // @param internalBalance Whether or not to use the internal balance or if a transfer is necessary
     // @param d The calldata for the redeem function -- described above in redeemABI
@@ -144,20 +162,12 @@ contract TermAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256) {
 
-        // Parse the calldata
-        (
-            address targetRedeemer,
-            address targetToken
-        ) = abi.decode(d, (address, address));
-
-        // TODO: Double check protocol enum
         address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
-        
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(
                 IERC20(pt),
-                lender,
+                msg.sender,
                 address(this),
                 amount
             );
@@ -165,7 +175,7 @@ contract TermAdapter is IAdapter {
 
         uint256 starting = IERC20(underlying_).balanceOf(address(this));
 
-        ITermRepoRedeemer(targetRedeemer).redeemTermRepoTokens(address(this), IERC20(targetToken).balanceOf(address(this)));
+        IYield(pt).redeem(address(this), uint128(amount));
 
         uint256 received = IERC20(underlying_).balanceOf(address(this)) - starting;
 

--- a/src/adapters/NotionalAdapter.sol
+++ b/src/adapters/NotionalAdapter.sol
@@ -42,7 +42,7 @@ contract NotionalAdapter is IAdapter {
 
     // @notice returns the protocol enum of this given adapter
     function protocol() public view returns (uint8) {
-        return (0);
+        return (8);
     }
 
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function

--- a/src/adapters/NotionalAdapter.sol
+++ b/src/adapters/NotionalAdapter.sol
@@ -40,6 +40,11 @@ contract NotionalAdapter is IAdapter {
         return INotional(pt).getMaturity();
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
     function lendABI(
     ) public pure {
@@ -51,21 +56,19 @@ contract NotionalAdapter is IAdapter {
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {
@@ -114,7 +117,7 @@ contract NotionalAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256, uint256) {
 
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[1]; // TODO: get yield PT enum
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()]; // TODO: get yield PT enum
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(
@@ -149,7 +152,7 @@ contract NotionalAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256) {
         // TODO: Double check protocol enum
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[7];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
         
         if (internalBalance == false){
             // Receive underlying funds, extract fees

--- a/src/adapters/PendleAdapter.sol
+++ b/src/adapters/PendleAdapter.sol
@@ -63,22 +63,25 @@ contract PendleAdapter  {
         Pendle.TokenOutput memory tokenOutput) {
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {

--- a/src/adapters/PendleAdapter.sol
+++ b/src/adapters/PendleAdapter.sol
@@ -65,7 +65,7 @@ contract PendleAdapter  {
 
     // @notice returns the protocol enum of this given adapter
     function protocol() public view returns (uint8) {
-        return (0);
+        return (4);
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -42,6 +42,11 @@ contract SwivelAdapter is IAdapter {
         return IERC5095(pt).maturity();
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
     // @returns orders The orders to be executed -- see Swivel for more info -- https://github.com/Swivel-Finance/swivel/blob/main/contracts/v4/src/lib/Hash.sol#L14
     // @returns components The components of the orders -- see Swivel for more info -- https://github.com/Swivel-Finance/swivel/blob/main/contracts/v4/src/lib/Sig.sol#L7
@@ -62,21 +67,19 @@ contract SwivelAdapter is IAdapter {
     }
     
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {
@@ -142,7 +145,7 @@ contract SwivelAdapter is IAdapter {
                 )
             );
 
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[1]; // TODO: Get Swivel PT enum
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()]; // TODO: Get Swivel PT enum
 
         address _underlying = IERC5095(pt).underlying();
 
@@ -226,7 +229,7 @@ contract SwivelAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256) {
 
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[0];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(

--- a/src/adapters/SwivelAdapter.sol
+++ b/src/adapters/SwivelAdapter.sol
@@ -44,7 +44,7 @@ contract SwivelAdapter is IAdapter {
 
     // @notice returns the protocol enum of this given adapter
     function protocol() public view returns (uint8) {
-        return (0);
+        return (1);
     }
 
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function

--- a/src/adapters/TermAdapter.sol
+++ b/src/adapters/TermAdapter.sol
@@ -40,6 +40,11 @@ contract TermAdapter is IAdapter {
         return (ITermToken(pt).config().redemptionTimestamp);
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
     // @returns minimum The minimum amount of the PTs to receive when spending (amount - fee)
     // @returns pool The address of the pool to lend to (buy PTs from)
@@ -59,21 +64,19 @@ contract TermAdapter is IAdapter {
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {
@@ -148,7 +151,7 @@ contract TermAdapter is IAdapter {
         ) = abi.decode(d, (address, address));
 
         // TODO: Double check protocol enum
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[7];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
         
         if (internalBalance == false){
             // Receive underlying funds, extract fees

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -39,6 +39,11 @@ contract YieldAdapter is IAdapter {
         return IYield(pt).maturity();
     }
 
+    // @notice returns the protocol enum of this given adapter
+    function protocol() public view returns (uint8) {
+        return (0);
+    }
+
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function
     // @returns minimum The minimum amount of the PTs to receive when spending (amount - fee)
     // @returns pool The address of the pool to lend to (buy PTs from)
@@ -56,21 +61,19 @@ contract YieldAdapter is IAdapter {
     }
 
     // @notice verifies that the provided underlying and maturity align with the provided PT address, enabling minting
-    // @param protocol The enum associated with the given market
     // @param underlying_ The address of the underlying token
     // @param maturity_ The maturity of the iPT 
     // @param targetToken The address of the token to be deposited -- note: If the market PT is not the same as the targetToken, underlying and maturity are validated
     // @param amount The amount of the targetToken to be deposited
     // @returns bool returns the amount of mintable iPTs
     function mint(
-        uint8 protocol, 
         address underlying_, 
         uint256 maturity_, 
         address targetToken, 
         uint256 amount
     ) external returns (uint256) {
         // Fetch the desired principal token
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
 
         // Disallow mints if market is not initialized (verifying the input underlying and maturity are valid)
         if (pt == address(0)) {
@@ -125,7 +128,7 @@ contract YieldAdapter is IAdapter {
             address pool
         ) = abi.decode(d, (uint256, address));
 
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[1]; // TODO: get yield PT enum
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()]; // TODO: get yield PT enum
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(
@@ -159,7 +162,7 @@ contract YieldAdapter is IAdapter {
         bytes calldata d
     ) external returns (uint256, uint256) {
 
-        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[0];
+        address pt = IMarketPlace(marketplace).markets(underlying_, maturity_).tokens[protocol()];
         if (internalBalance == false){
             // Receive underlying funds, extract fees
             Safe.transferFrom(

--- a/src/adapters/YieldAdapter.sol
+++ b/src/adapters/YieldAdapter.sol
@@ -41,7 +41,7 @@ contract YieldAdapter is IAdapter {
 
     // @notice returns the protocol enum of this given adapter
     function protocol() public view returns (uint8) {
-        return (0);
+        return (2);
     }
 
     // @notice lendABI "returns" the arguments required in the bytes `d` for the lend function

--- a/src/interfaces/IAdapter.sol
+++ b/src/interfaces/IAdapter.sol
@@ -5,7 +5,8 @@ pragma solidity 0.8.20;
 interface IAdapter {
     function underlying(address pt) external view returns (address);
     function maturity(address pt) external view returns (uint256);
-    function mint(uint8 protocol, address underlying_, uint256 maturity_, address targetToken, uint256 amount) external returns (uint256);
+    function protocol() external view returns (uint8);
+    function mint(address underlying_, uint256 maturity_, address targetToken, uint256 amount) external returns (uint256);
     function lend(address underlying_, uint256 maturity_, uint256[] calldata amount, bool internalBalance, bytes calldata d) external returns (uint256, uint256, uint256);
     function redeem(address underlying_, uint256 maturity_, uint256 amount, bool internalBalance, bytes calldata d) external returns (uint256, uint256);
 }

--- a/src/interfaces/ILender.sol
+++ b/src/interfaces/ILender.sol
@@ -32,4 +32,6 @@ interface ILender {
     function curvePools(address) external returns (address);
 
     function convertDecimals(address, address, uint256) external view returns (uint256);
+
+    function principalApprove(address[] calldata pt) external returns (bool);
 }


### PR DESCRIPTION
Essentially it looks like sourabh included some `approve()` methods assuming they needed to be called in the proxy within the marketplace.

When reviewing and removing those as they are redundant / unnecessary (the marketplace doesnt ever have balances, it serves as a router that passes balances along without ever actually "owning" the tokens), I also noticed that the workflow for approving the redeemer to pull PTs from the lender was cumbersome and required manual intervention.

To simplify this I created an auth method from the marketplace -> lender that allows the marketplace to trigger approvals from the lender -> redeemer.

Then, this method is called in `setPrincipal` and `createMarket`, meaning these approvals are automatically set when creating markets going forward.