### PR TITLE
Feenominator scaling

### DIFF
--- a/src/adapters/ExactlyAdapter.sol
+++ b/src/adapters/ExactlyAdapter.sol
@@ -147,7 +147,7 @@ contract ExactlyAdapter is IAdapter {
         (uint256 returned) = IExactly(exactlyToken).depositAtMaturity(exactlyMaturity, amount[0], minimumAssets, address(this));
         // TODO: consider changing address(this) to the redeemer if transfer isnt possible 
 
-        return (returned, amount[0], amount[0] / ILender(lender).feenominator());
+        return (returned, amount[0], amount[0] / ILender(lender).feenominator(maturity_));
     }
 
     // @notice After maturity, redeem `amount` of the underlying token from the X protocol

--- a/src/interfaces/ILender.sol
+++ b/src/interfaces/ILender.sol
@@ -21,7 +21,7 @@ interface ILender {
 
     function halted() external returns (bool);
 
-    function feenominator() external returns (uint256);
+    function feenominator(uint256) external returns (uint256);
 
     function protocolRouters(uint256) external returns (address);
 


### PR DESCRIPTION
I wont be merging until I settle on the design (as mentioned in discord) but this is the base idea behind scaling the feenominator.

You allow shorter term maturities to scale their fee, ensuring users lending close to the maturity date do not face excess fees.

What Ive already done:
Assume a base fee for a 10 yr market and scale down linearly from there

This is easy, is most gas efficient, but for longer term markets also means it scales UP because i havent implemented an exponential function. I could get an exponential function in there but that reduces gas efficiency a bit.

Or alternatively I can:
Store the starting time for each market in a mapping within the marketplace. Use that to scale linearly. This is probably least gas efficient, but overall the most accurate.
Going to PR the first and likely go for the 2nd or add an exponential function (weve got the libs for it available)