### PR TITLE
Expand enum + fix mint delegateCall interface

### DIFF
--- a/src/interfaces/IMarketPlace.sol
+++ b/src/interfaces/IMarketPlace.sol
@@ -13,7 +13,9 @@ interface IMarketPlace {
         Tempus, // 5
         Sense, // 6
         Apwine, // 7
-        Notional // 8
+        Notional, // 8
+        Term, // 9
+        Swivelv3 //10
     }
     
     struct Market {


### PR DESCRIPTION
Tiny change to update the principals enum (although this may be dynamic we should have an "on release" version in the marketplace interface)

As well as an update from `uint8` -> `address` in the `mint()` delegate call interface.